### PR TITLE
initial stab at collision fields

### DIFF
--- a/mujoco/mjx/__init__.py
+++ b/mujoco/mjx/__init__.py
@@ -1,20 +1,24 @@
 """Public API for MJX."""
 
-from ._src.forward import forward
-from ._src.forward import fwd_acceleration
-from ._src.forward import fwd_position
-from ._src.forward import fwd_velocity
-from ._src.io import make_data
-from ._src.io import put_data
-from ._src.io import put_model
-from ._src.passive import passive
-from ._src.smooth import com_pos
-from ._src.smooth import com_vel
-from ._src.smooth import crb
-from ._src.smooth import factor_m
-from ._src.smooth import solve_m
-from ._src.smooth import kinematics
-from ._src.smooth import rne
-from ._src.support import is_sparse
-from ._src.test_util import benchmark
-from ._src.types import *
+from ._src.collision_driver import collision as collision
+from ._src.forward import forward as forward
+from ._src.forward import fwd_acceleration as fwd_acceleration
+from ._src.forward import fwd_position as fwd_position
+from ._src.forward import fwd_velocity as fwd_velocity
+from ._src.io import make_data as make_data
+from ._src.io import put_data as put_data
+from ._src.io import put_model as put_model
+from ._src.passive import passive as passive
+from ._src.smooth import com_pos as com_pos
+from ._src.smooth import com_vel as com_vel
+from ._src.smooth import crb as crb
+from ._src.smooth import factor_m as factor_m
+from ._src.smooth import solve_m as solve_m
+from ._src.smooth import kinematics as kinematics
+from ._src.smooth import rne as rne
+from ._src.support import is_sparse as is_sparse
+from ._src.test_util import benchmark as benchmark
+from ._src.types import Contact as Contact
+from ._src.types import Data as Data
+from ._src.types import Model as Model
+from ._src.types import Option as Option

--- a/mujoco/mjx/_src/collision_driver.py
+++ b/mujoco/mjx/_src/collision_driver.py
@@ -1,0 +1,21 @@
+import warp as wp
+
+from .types import Model
+from .types import Data
+
+
+def collision(m: Model, d: Data):
+  """Main collision function."""
+
+  @wp.kernel
+  def _root(m: Model, d: Data):
+    d.ncon_total[0] = 0
+  
+  wp.launch(_root, dim=(1,), inputs=[m, d])
+
+
+
+def broadphase(m: Model, d: Data):
+  """Broadphase collision detector."""
+  # TODO(team): sweep and prune instead of n^2
+

--- a/mujoco/mjx/_src/collision_driver_test.py
+++ b/mujoco/mjx/_src/collision_driver_test.py
@@ -1,0 +1,36 @@
+"""Tests for collision driver."""
+
+from absl.testing import absltest
+from mujoco import mjx
+import numpy as np
+import warp as wp
+
+from . import test_util
+
+# tolerance for difference between MuJoCo and MJX smooth calculations - mostly
+# due to float precision
+_TOLERANCE = 5e-5
+
+def _assert_eq(a, b, name):
+  tol = _TOLERANCE * 10  # avoid test noise
+  err_msg = f'mismatch: {name}'
+  np.testing.assert_allclose(a, b, err_msg=err_msg, atol=tol, rtol=tol)
+
+
+class CollisionDriverTest(absltest.TestCase):
+
+  def test_collision(self):
+    """Tests collision."""
+    _, mjd, m, d = test_util.fixture('pendula.xml')
+
+    for arr in (d.qfrc_spring, d.qfrc_damper, d.qfrc_passive):
+      arr.zero_()
+
+    mjx.collision(m, d)
+
+
+
+
+if __name__ == '__main__':
+  wp.init()
+  absltest.main()

--- a/mujoco/mjx/_src/types.py
+++ b/mujoco/mjx/_src/types.py
@@ -22,6 +22,7 @@ class Model:
   nsite: int
   nmocap: int
   nM: int
+  nconmax: int
   opt: Option
   qpos0: wp.array(dtype=wp.float32, ndim=1)
   qpos_spring: wp.array(dtype=wp.float32, ndim=1)
@@ -65,8 +66,31 @@ class Model:
 
 
 @wp.struct
+class Contact:
+   dist: wp.float32
+   pos: wp.vec3
+   frame: wp.mat33
+   includemargin: wp.float32
+   friction: wp.types.vector(length=5, dtype=wp.float32)
+   solref: wp.vec2
+   solreffriction: wp.vec2
+   solimp: wp.types.vector(length=5, dtype=wp.float32)
+   # TODO(team): should dim be int8?
+   dim: wp.int32
+   # TODO(team): should exclude be int8?
+   exclude: wp.int32
+   geom: wp.vec2i
+   efc_address: wp.int32
+   worldid: wp.int32
+
+
+@wp.struct
 class Data:
   nworld: int
+  nconmax: int
+  ncon: wp.array(dtype=wp.int32, ndim=1)
+  # TODO(team): is there a way to express a device scalar or just leave this array(length=1)?
+  ncon_total: wp.array(dtype=wp.int32, ndim=1)  # warp only
   qpos: wp.array(dtype=wp.float32, ndim=2)
   qvel: wp.array(dtype=wp.float32, ndim=2)
   qfrc_applied: wp.array(dtype=wp.float32, ndim=2)
@@ -102,3 +126,4 @@ class Data:
   qfrc_actuator: wp.array(dtype=wp.float32, ndim=2)
   qfrc_smooth: wp.array(dtype=wp.float32, ndim=2)
   qacc_smooth: wp.array(dtype=wp.float32, ndim=2)
+  contact: wp.array(dtype=Contact, ndim=1)


### PR DESCRIPTION
DO NOT MERGE - WIP

Here's my thinking:

User will ultimately have three parameters that control the size of `Data`:

1. nworld: number of distinct worlds in `Data`
2. nconmax: max number of contacts shared across all worlds in `Data`
3. njmax: max number of constraints shred across all worlds in `Data`

These are optional parameters to `make_data` and `put_data` and we should be able to come up with some reasonable defaults.  We may choose fairly greedy defaults (JAX preallocates like 75% of GPU memory anyway right?)

In order to track number of contacts, we introduce three arrays:
1. `contact` which is the contact metadata, and includes a pointer back to both the world id and the first constraint row id
2. `ncon` which is like MuJoCo, but is batched, so it contains number of contacts per each world
3. `total_ncon` which is a size 1 array, that tracks the total number of contacts across all worlds.  `total_ncon` can be > `nconmax` after a physics step.  This indicates an overflow occurred and some contacts were lost.