### PR TITLE
update contact

### DIFF
--- a/mujoco/mjx/_src/constraint.py
+++ b/mujoco/mjx/_src/constraint.py
@@ -149,7 +149,7 @@ def _efc_contact_pyramidal(
 
   if conid >= d.ncon_total[0]:
     return
-  
+
   if d.contact.dim[conid] != 3:
     return
 

--- a/mujoco/mjx/_src/types.py
+++ b/mujoco/mjx/_src/types.py
@@ -126,10 +126,15 @@ class ConeType(enum.IntEnum):
   ELLIPTIC = mujoco.mjtCone.mjCONE_ELLIPTIC
 
 
+class vec5f(wp.types.vector(length=5, dtype=wp.float32)):
+  pass
+
+
 class vec10f(wp.types.vector(length=10, dtype=wp.float32)):
   pass
 
 
+vec5 = vec5f
 vec10 = vec10f
 array2df = wp.array2d(dtype=wp.float32)
 array3df = wp.array3d(dtype=wp.float32)
@@ -200,8 +205,8 @@ class Model:
   jnt_bodyid: wp.array(dtype=wp.int32, ndim=1)
   jnt_limited: wp.array(dtype=wp.int32, ndim=1)
   jnt_limited_slide_hinge_adr: wp.array(dtype=wp.int32, ndim=1)  # warp only
-  jnt_solref: wp.array(dtype=wp.float32, ndim=2)
-  jnt_solimp: wp.array(dtype=wp.float32, ndim=2)
+  jnt_solref: wp.array(dtype=wp.vec2f, ndim=1)
+  jnt_solimp: wp.array(dtype=vec5, ndim=1)
   jnt_type: wp.array(dtype=wp.int32, ndim=1)
   jnt_qposadr: wp.array(dtype=wp.int32, ndim=1)
   jnt_dofadr: wp.array(dtype=wp.int32, ndim=1)
@@ -246,23 +251,26 @@ class Model:
 
 @wp.struct
 class Contact:
-  dist: wp.array(dtype=wp.float32, ndim=2)
-  pos: wp.array(dtype=wp.vec3f, ndim=2)
-  frame: wp.array(dtype=wp.mat33f, ndim=2)
-  includemargin: wp.array(dtype=wp.float32, ndim=2)
-  friction: wp.array(dtype=wp.float32, ndim=3)
-  solref: wp.array(dtype=wp.float32, ndim=3)
-  solreffriction: wp.array(dtype=wp.float32, ndim=3)
-  solimp: wp.array(dtype=wp.float32, ndim=3)
-  dim: wp.array(dtype=wp.int32, ndim=2)
-  geom: wp.array(dtype=wp.int32, ndim=3)
-  efc_address: wp.array(dtype=wp.int32, ndim=2)
+  dist: wp.array(dtype=wp.float32, ndim=1)
+  pos: wp.array(dtype=wp.vec3f, ndim=1)
+  frame: wp.array(dtype=wp.mat33f, ndim=1)
+  includemargin: wp.array(dtype=wp.float32, ndim=1)
+  friction: wp.array(dtype=vec5, ndim=1)
+  solref: wp.array(dtype=wp.vec2f, ndim=1)
+  solreffriction: wp.array(dtype=wp.vec2f, ndim=1)
+  solimp: wp.array(dtype=vec5, ndim=1)
+  dim: wp.array(dtype=wp.int32, ndim=1)
+  geom: wp.array(dtype=wp.vec2i, ndim=1)
+  efc_address: wp.array(dtype=wp.int32, ndim=1)
+  worldid: wp.array(dtype=wp.int32, ndim=1)
 
 
 @wp.struct
 class Data:
   nworld: int
+  ncon_total: wp.array(dtype=wp.int32, ndim=1)  # warp only
   nefc_total: wp.array(dtype=wp.int32, ndim=1)  # warp only
+  nconmax: int
   njmax: int
   time: float
   qpos: wp.array(dtype=wp.float32, ndim=2)


### PR DESCRIPTION
`test_util.benchmark` was temporarily modified to load a keyframe, call `mj_forward`, and then create `Data` using `put_data` in order to generate these benchmarking results.

```
d = mujoco.MjData(m)
mujoco.mj_resetDataKeyframe(m, d, 0)
mujoco.mj_forward(m, d)
mx = io.put_model(m)
dx = io.put_data(m, d)
```

keyframe `0` for the humanoid results in `nefc=32` (comprising four pyramidal friction contacts with condim=3)

```
mjx-testspeed --function=make_constraint --mjcf=humanoid/humanoid.xml --batch_size=8192
```

this pr:
```
Summary for 8192 parallel rollouts

 Total JIT time: 1.47 s
 Total simulation time: 0.06 s
 Total steps per second: 136,651,564
 Total realtime factor: 683,257.82 x
 Total time per step: 0.01 µs
```

main:
```
Summary for 8192 parallel rollouts

 Total JIT time: 1.51 s
 Total simulation time: 0.06 s
 Total steps per second: 130,614,030
 Total realtime factor: 653,070.15 x
 Total time per step: 0.01 µs
```