### PR TITLE
Run warmup twice in testspeed, revert block size changes

### DIFF
--- a/mujoco/mjx/_src/smooth.py
+++ b/mujoco/mjx/_src/smooth.py
@@ -320,7 +320,7 @@ def _factor_i_dense(m: Model, d: Data, M: wp.array, L: wp.array):
   """Dense Cholesky factorizaton of inertia-like matrix M, assumed spd."""
 
   # TODO(team): develop heuristic for block dim, or make configurable
-  block_dim = 256
+  block_dim = 32
 
   def tile_cholesky(adr: int, size: int, tilesize: int):
     @wp.kernel
@@ -620,7 +620,7 @@ def _solve_LD_dense(m: Model, d: Data, L: array3df, x: array2df, y: array2df):
   """Computes dense backsubstitution: x = inv(L'*L)*y"""
 
   # TODO(team): develop heuristic for block dim, or make configurable
-  block_dim = 256
+  block_dim = 32
 
   def tile_cho_solve(adr: int, size: int, tilesize: int):
     @wp.kernel

--- a/mujoco/mjx/_src/solver.py
+++ b/mujoco/mjx/_src/solver.py
@@ -323,7 +323,7 @@ def _update_gradient(m: types.Model, d: types.Data, ctx: Context):
       output_tile = wp.tile_cholesky_solve(fact_tile, input_tile)
       wp.tile_store(ctx.Mgrad[worldid], output_tile)
 
-    wp.launch_tiled(_cholesky, dim=(d.nworld,), inputs=[ctx], block_dim=256)
+    wp.launch_tiled(_cholesky, dim=(d.nworld,), inputs=[ctx], block_dim=32)
 
 
 @wp.func

--- a/mujoco/mjx/_src/test_util.py
+++ b/mujoco/mjx/_src/test_util.py
@@ -72,6 +72,7 @@ def benchmark(
   wp.clear_kernel_cache()
   jit_beg = time.perf_counter()
   fn(mx, dx)
+  fn(mx, dx) # double warmup to work around issues with compilation during graph capture
   jit_end = time.perf_counter()
   jit_duration = jit_end - jit_beg
   wp.synchronize()


### PR DESCRIPTION
I suggest to just run warmup twice to work around blocksize issues. Of course, a different option is just to upgrade your CUDA version.