### PR TITLE
newton solve sparse qM

### DIFF
--- a/mujoco/mjx/_src/solver.py
+++ b/mujoco/mjx/_src/solver.py
@@ -276,18 +276,40 @@ def _update_gradient(m: types.Model, d: types.Data, ctx: Context):
   if m.opt.solver == 1:  # CG
     smooth.solve_m(m, d, ctx.grad, ctx.Mgrad)
   elif m.opt.solver == 2:  # Newton
-    # TODO(team): sparse version
     # h = qM + (efc_J.T * efc_D * active) @ efc_J
-    @wp.kernel
-    def _copy_lower_triangle(m: types.Model, d: types.Data, ctx: Context):
-      worldid, elementid = wp.tid()
-      rowid = m.dof_tri_row[elementid]
-      colid = m.dof_tri_col[elementid]
-      ctx.h[worldid, rowid, colid] = d.qM[worldid, rowid, colid]
+    if m.opt.is_sparse:
 
-    wp.launch(
-      _copy_lower_triangle, dim=(d.nworld, m.dof_tri_row.size), inputs=[m, d, ctx]
-    )
+      @wp.kernel
+      def _zero_h_lower(m: types.Model, ctx: Context):
+        worldid, elementid = wp.tid()
+        rowid = m.dof_tri_row[elementid]
+        colid = m.dof_tri_col[elementid]
+        ctx.h[worldid, rowid, colid] = 0.0
+
+      wp.launch(_zero_h_lower, dim=(d.nworld, m.dof_tri_row.size), inputs=[m, ctx])
+
+      @wp.kernel
+      def _set_h_qM_lower_sparse(m: types.Model, d: types.Data, ctx: Context):
+        worldid, elementid = wp.tid()
+        i = m.qM_fullm_i[elementid]
+        j = m.qM_fullm_j[elementid]
+        ctx.h[worldid, i, j] = d.qM[worldid, 0, elementid]
+
+      wp.launch(
+        _set_h_qM_lower_sparse, dim=(d.nworld, m.qM_fullm_i.size), inputs=[m, d, ctx]
+      )
+    else:
+
+      @wp.kernel
+      def _copy_lower_triangle(m: types.Model, d: types.Data, ctx: Context):
+        worldid, elementid = wp.tid()
+        rowid = m.dof_tri_row[elementid]
+        colid = m.dof_tri_col[elementid]
+        ctx.h[worldid, rowid, colid] = d.qM[worldid, rowid, colid]
+
+      wp.launch(
+        _copy_lower_triangle, dim=(d.nworld, m.dof_tri_row.size), inputs=[m, d, ctx]
+      )
 
     @wp.kernel
     def _JTDAJ(ctx: Context, m: types.Model, d: types.Data):
@@ -304,6 +326,7 @@ def _update_gradient(m: types.Model, d: types.Data, ctx: Context):
         return
 
       worldid = d.efc_worldid[efcid]
+      # TODO(team): sparse efc_J
       wp.atomic_add(
         ctx.h[worldid, dofi],
         dofj,

--- a/mujoco/mjx/_src/solver_test.py
+++ b/mujoco/mjx/_src/solver_test.py
@@ -50,15 +50,16 @@ class SolverTest(parameterized.TestCase):
     return mjm, mjd, m, d
 
   @parameterized.parameters(
-    (mujoco.mjtCone.mjCONE_PYRAMIDAL, mujoco.mjtSolver.mjSOL_CG, 25, 5),
-    (mujoco.mjtCone.mjCONE_PYRAMIDAL, mujoco.mjtSolver.mjSOL_NEWTON, 2, 4),
+    (mujoco.mjtCone.mjCONE_PYRAMIDAL, mujoco.mjtSolver.mjSOL_CG, 25, 5, False),
+    (mujoco.mjtCone.mjCONE_PYRAMIDAL, mujoco.mjtSolver.mjSOL_NEWTON, 2, 4, False),
+    (mujoco.mjtCone.mjCONE_PYRAMIDAL, mujoco.mjtSolver.mjSOL_NEWTON, 2, 4, True),
   )
-  def test_solve(self, cone, solver_, iterations, ls_iterations):
+  def test_solve(self, cone, solver_, iterations, ls_iterations, sparse):
     """Tests MJX solve."""
     for keyframe in range(3):
       mjm, mjd, m, d = self._load(
         "humanoid/humanoid.xml",
-        is_sparse=False,
+        is_sparse=sparse,
         cone=cone,
         solver_=solver_,
         iterations=iterations,

--- a/mujoco/mjx/_src/support.py
+++ b/mujoco/mjx/_src/support.py
@@ -72,8 +72,8 @@ def mul_m(
       vec: wp.array(ndim=2, dtype=wp.float32),
     ):
       worldid, elementid = wp.tid()
-      i = m.qM_i[elementid]
-      j = m.qM_j[elementid]
+      i = m.qM_mulm_i[elementid]
+      j = m.qM_mulm_j[elementid]
       madr_ij = m.qM_madr_ij[elementid]
 
       qM = d.qM[worldid, 0, madr_ij]

--- a/mujoco/mjx/_src/test_util.py
+++ b/mujoco/mjx/_src/test_util.py
@@ -72,7 +72,9 @@ def benchmark(
   wp.clear_kernel_cache()
   jit_beg = time.perf_counter()
   fn(mx, dx)
-  fn(mx, dx) # double warmup to work around issues with compilation during graph capture
+  fn(
+    mx, dx
+  )  # double warmup to work around issues with compilation during graph capture
   jit_end = time.perf_counter()
   jit_duration = jit_end - jit_beg
   wp.synchronize()

--- a/mujoco/mjx/_src/test_util.py
+++ b/mujoco/mjx/_src/test_util.py
@@ -31,6 +31,7 @@ from . import types
 def fixture(fname: str, keyframe: int = -1, sparse: bool = True):
   path = epath.resource_path("mujoco.mjx") / "test_data" / fname
   mjm = mujoco.MjModel.from_xml_path(path.as_posix())
+  mjm.opt.jacobian = sparse
   mjd = mujoco.MjData(mjm)
   if keyframe > -1:
     mujoco.mj_resetDataKeyframe(mjm, mjd, keyframe)
@@ -38,7 +39,6 @@ def fixture(fname: str, keyframe: int = -1, sparse: bool = True):
   mjd.qvel = np.random.uniform(-0.01, 0.01, mjm.nv)
   mujoco.mj_step(mjm, mjd, 3)  # let dynamics get state significantly non-zero
   mujoco.mj_forward(mjm, mjd)
-  mjm.opt.jacobian = sparse
   m = io.put_model(mjm)
   d = io.put_data(mjm, mjd)
   return mjm, mjd, m, d

--- a/mujoco/mjx/_src/types.py
+++ b/mujoco/mjx/_src/types.py
@@ -179,8 +179,10 @@ class Model:
   qpos_spring: wp.array(dtype=wp.float32, ndim=1)
   body_tree: wp.array(dtype=wp.int32, ndim=1)  # warp only
   body_treeadr: wp.array(dtype=wp.int32, ndim=1)  # warp only
-  qM_i: wp.array(dtype=wp.int32, ndim=1)  # warp only
-  qM_j: wp.array(dtype=wp.int32, ndim=1)  # warp only
+  qM_fullm_i: wp.array(dtype=wp.int32, ndim=1)  # warp only
+  qM_fullm_j: wp.array(dtype=wp.int32, ndim=1)  # warp only
+  qM_mulm_i: wp.array(dtype=wp.int32, ndim=1)  # warp only
+  qM_mulm_j: wp.array(dtype=wp.int32, ndim=1)  # warp only
   qM_madr_ij: wp.array(dtype=wp.int32, ndim=1)  # warp only
   qLD_update_tree: wp.array(dtype=wp.vec3i, ndim=1)  # warp only
   qLD_update_treeadr: wp.array(dtype=wp.int32, ndim=1)  # warp only


### PR DESCRIPTION
the Newton solver is updated to work with a sparse representation of `qM`.

sparse:
```
mjx-testspeed --function=forward --is_sparse=True --mjcf=humanoid/humanoid.xml --batch_size=8192 --nefc_total=32768 --solver=newton --iterations=
1 --ls_iterations=5
```
```
Summary for 8192 parallel rollouts

 Total JIT time: 108.24 s
 Total simulation time: 4.16 s
 Total steps per second: 1,970,182
 Total realtime factor: 9,850.91 x
 Total time per step: 0.51 µs
```

dense:
```
mjx-testspeed --function=forward --is_sparse=False --mjcf=humanoid/humanoid.xml --batch_size=8192 --nefc_total=32768 --solver=newton --iterations=1 --ls_iterations=5
```
```
Summary for 8192 parallel rollouts

 Total JIT time: 122.94 s
 Total simulation time: 4.19 s
 Total steps per second: 1,953,057
 Total realtime factor: 9,765.28 x
 Total time per step: 0.51 µs
```