### PR TITLE
Testspeed fixes

### DIFF
--- a/mujoco/mjx/_src/io.py
+++ b/mujoco/mjx/_src/io.py
@@ -353,11 +353,11 @@ def put_data(
   # TODO(team): move to Model?
   if nconmax == -1:
     # TODO(team): heuristic for nconmax
-    nconmax = 512
+    nconmax = max(512, mjd.ncon * nworld)
   d.nconmax = nconmax
   if njmax == -1:
     # TODO(team): heuristic for njmax
-    njmax = 512
+    njmax = max(512, mjd.nefc * nworld)
   d.njmax = njmax
 
   if nworld * mjd.nefc > njmax:

--- a/mujoco/mjx/testspeed.py
+++ b/mujoco/mjx/testspeed.py
@@ -92,9 +92,7 @@ def _main(argv: Sequence[str]):
   print(
     f"Model nbody: {m.nbody} nv: {m.nv} ngeom: {m.ngeom} is_sparse: {_IS_SPARSE.value}"
   )
-  print(
-    f"Data ncon: {d.ncon} nefc: {d.nefc}"
-  )
+  print(f"Data ncon: {d.ncon} nefc: {d.nefc}")
   print(f"Rolling out {_NSTEP.value} steps at dt = {m.opt.timestep:.3f}...")
   jit_time, run_time, steps = mjx.benchmark(
     mjx.__dict__[_FUNCTION.value],


### PR DESCRIPTION
Assumes that the benchmark model proposes reasonable nefc, ncon given a keyframe.

Changes testspeed flags to take nconmax, njmax.