### PR TITLE
Tiled mul_m.

### DIFF
--- a/mujoco/mjx/_src/support.py
+++ b/mujoco/mjx/_src/support.py
@@ -40,7 +40,7 @@ def mul_m(
     def tile_mul(adr: int, size: int, tilesize: int):
       # TODO(team): speed up kernel compile time (14s on 2023 Macbook Pro)
       @wp.kernel
-      def mul(m: Model, d: Data, leveladr: int, vec: array3df, res: array3df):
+      def mul(m: Model, d: Data, leveladr: int, res: array3df, vec: array3df):
         worldid, nodeid = wp.tid()
         dofid = m.qLD_tile[leveladr + nodeid]
         qM_tile = wp.tile_load(

--- a/mujoco/mjx/_src/support.py
+++ b/mujoco/mjx/_src/support.py
@@ -38,6 +38,7 @@ def mul_m(
   if not m.opt.is_sparse:
 
     def tile_mul(adr: int, size: int, tilesize: int):
+      # TODO(team): speed up kernel compile time (14s on 2023 Macbook Pro)
       @wp.kernel
       def mul(m: Model, d: Data, leveladr: int, vec: array3df, res: array3df):
         worldid, nodeid = wp.tid()

--- a/mujoco/mjx/_src/support.py
+++ b/mujoco/mjx/_src/support.py
@@ -18,6 +18,7 @@ import warp as wp
 from .types import Model
 from .types import Data
 from .types import array2df
+from .types import array3df
 
 
 def is_sparse(m: mujoco.MjModel):
@@ -35,21 +36,41 @@ def mul_m(
   """Multiply vector by inertia matrix."""
 
   if not m.opt.is_sparse:
-    # TODO(team): tile_matmul
-    res.zero_()
 
-    @wp.kernel
-    def _mul_m_dense(
-      d: Data,
-      res: wp.array(ndim=2, dtype=wp.float32),
-      vec: wp.array(ndim=2, dtype=wp.float32),
-    ):
-      worldid, rowid, colid = wp.tid()
-      wp.atomic_add(
-        res[worldid], rowid, d.qM[worldid, rowid, colid] * vec[worldid, colid]
+    def tile_mul(adr: int, size: int, tilesize: int):
+      @wp.kernel
+      def mul(m: Model, d: Data, leveladr: int, vec: array3df, res: array3df):
+        worldid, nodeid = wp.tid()
+        dofid = m.qLD_tile[leveladr + nodeid]
+        qM_tile = wp.tile_load(
+          d.qM[worldid], shape=(tilesize, tilesize), offset=(dofid, dofid)
+        )
+        vec_tile = wp.tile_load(vec[worldid], shape=(tilesize, 1), offset=(dofid, 0))
+        res_tile = wp.tile_zeros(shape=(tilesize, 1), dtype=wp.float32)
+        wp.tile_matmul(qM_tile, vec_tile, res_tile)
+        wp.tile_store(res[worldid], res_tile, offset=(dofid, 0))
+
+      wp.launch_tiled(
+        mul,
+        dim=(d.nworld, size),
+        inputs=[
+          m,
+          d,
+          adr,
+          res.reshape(res.shape + (1,)),
+          vec.reshape(vec.shape + (1,)),
+        ],
+        # TODO(team): develop heuristic for block dim, or make configurable
+        block_dim=32,
       )
 
-    wp.launch(_mul_m_dense, dim=(d.nworld, m.nv, m.nv), inputs=[d, res, vec])
+    qLD_tileadr, qLD_tilesize = m.qLD_tileadr.numpy(), m.qLD_tilesize.numpy()
+
+    for i in range(len(qLD_tileadr)):
+      beg = qLD_tileadr[i]
+      end = m.qLD_tile.shape[0] if i == len(qLD_tileadr) - 1 else qLD_tileadr[i + 1]
+      tile_mul(beg, end - beg, int(qLD_tilesize[i]))
+
   else:
 
     @wp.kernel


### PR DESCRIPTION
Result of `mjx-testspeed --function=solve --is_sparse=False --mjcf=humanoid/humanoid.xml --batch_size=8192`

This branch:

```
Summary for 8192 parallel rollouts

 Total JIT time: 14.99 s
 Total simulation time: 1.33 s
 Total steps per second: 6,141,383
 Total realtime factor: 30,706.92 x
 Total time per step: 162.83 ns
```

main:

```
Summary for 8192 parallel rollouts

 Total JIT time: 0.89 s
 Total simulation time: 1.53 s
 Total steps per second: 5,363,853
 Total realtime factor: 26,819.26 x
 Total time per step: 186.43 ns
```

Note that compilation for tiled `mul_m` is quite slow:

```
Module mujoco.mjx._src.support 9a7a6e8 load on device 'cuda:0' took 14520.68 ms  (compiled)
```

Left a TODO - might need some help to debug what's going on there later.