### PR TITLE
compute qfrc_actuator with tile operations

### DIFF
--- a/mujoco/mjx/_src/forward.py
+++ b/mujoco/mjx/_src/forward.py
@@ -442,26 +442,97 @@ def fwd_actuation(m: Model, d: Data):
     _force, dim=[d.nworld, m.nu], inputs=[m, d.ctrl], outputs=[d.actuator_force]
   )
 
-  @wp.kernel
-  def _qfrc(m: Model, moment: array3df, force: array2df, qfrc: array2df):
-    worldid, vid = wp.tid()
+  if m.opt.is_sparse:
+    # TODO(team): sparse version
+    @wp.kernel
+    def _qfrc(m: Model, moment: array3df, force: array2df, qfrc: array2df):
+      worldid, vid = wp.tid()
 
-    s = float(0.0)
-    for uid in range(m.nu):
-      # TODO consider using Tile API or transpose moment for better access pattern
-      s += moment[worldid, uid, vid] * force[worldid, uid]
-    jntid = m.dof_jntid[vid]
-    if m.jnt_actfrclimited[jntid]:
-      r = m.jnt_actfrcrange[jntid]
-      s = wp.clamp(s, r[0], r[1])
-    qfrc[worldid, vid] = s
+      s = float(0.0)
+      for uid in range(m.nu):
+        # TODO consider using Tile API or transpose moment for better access pattern
+        s += moment[worldid, uid, vid] * force[worldid, uid]
+      jntid = m.dof_jntid[vid]
+      if m.jnt_actfrclimited[jntid]:
+        r = m.jnt_actfrcrange[jntid]
+        s = wp.clamp(s, r[0], r[1])
+      qfrc[worldid, vid] = s
 
-  wp.launch(
-    _qfrc,
-    dim=(d.nworld, m.nv),
-    inputs=[m, d.actuator_moment, d.actuator_force],
-    outputs=[d.qfrc_actuator],
-  )
+    wp.launch(
+      _qfrc,
+      dim=(d.nworld, m.nv),
+      inputs=[m, d.actuator_moment, d.actuator_force],
+      outputs=[d.qfrc_actuator],
+    )
+
+  else:
+
+    def qfrc_actuator(adr: int, size: int, tilesize_nu: int, tilesize_nv: int):
+      @wp.kernel
+      def qfrc_actuator_kernel(
+        m: Model,
+        d: Data,
+        leveladr: int,
+        qfrc_actuator: array3df,
+        actuator_force: array3df,
+      ):
+        worldid, nodeid = wp.tid()
+        offset_nu = m.qderiv_implicit_offset_nu[leveladr + nodeid]
+        offset_nv = m.qderiv_implicit_offset_nv[leveladr + nodeid]
+
+        actuator_moment_tile = wp.tile_load(
+          d.actuator_moment[worldid],
+          shape=(tilesize_nu, tilesize_nv),
+          offset=(offset_nu, offset_nv),
+        )
+        actuator_moment_T_tile = wp.tile_transpose(actuator_moment_tile)
+
+        force_tile = wp.tile_load(
+          actuator_force[worldid], shape=(tilesize_nu, 1), offset=(offset_nu, 0)
+        )
+        qfrc_tile = wp.tile_matmul(actuator_moment_T_tile, force_tile)
+        wp.tile_store(qfrc_actuator[worldid], qfrc_tile, offset=(offset_nv, 0))
+
+      wp.launch_tiled(
+        qfrc_actuator_kernel,
+        dim=(d.nworld, size),
+        inputs=[
+          m,
+          d,
+          adr,
+          d.qfrc_actuator.reshape(d.qfrc_actuator.shape + (1,)),
+          d.actuator_force.reshape(d.actuator_force.shape + (1,)),
+        ],
+        block_dim=32,
+      )
+
+    qderiv_tilesize_nu = m.qderiv_implicit_tilesize_nu.numpy()
+    qderiv_tilesize_nv = m.qderiv_implicit_tilesize_nv.numpy()
+    qderiv_tileadr = m.qderiv_implicit_tileadr.numpy()
+
+    for i in range(len(qderiv_tileadr)):
+      beg = qderiv_tileadr[i]
+      end = (
+        m.qderiv_implicit_tileadr.shape[0]
+        if i == len(qderiv_tileadr) - 1
+        else qderiv_tileadr[i + 1]
+      )
+      qfrc_actuator(
+        beg, end - beg, int(qderiv_tilesize_nu[i]), int(qderiv_tilesize_nv[i])
+      )
+
+    @wp.kernel
+    def _qfrc_limited(m: Model, d: Data):
+      worldid, dofid = wp.tid()
+      jntid = m.dof_jntid[dofid]
+      if m.jnt_actfrclimited[jntid]:
+        d.qfrc_actuator[worldid, dofid] = wp.clamp(
+          d.qfrc_actuator[worldid, dofid],
+          m.jnt_actfrcrange[jntid][0],
+          m.jnt_actfrcrange[jntid][1],
+        )
+
+    wp.launch(_qfrc_limited, dim=(d.nworld, m.nv), inputs=[m, d])
 
   # TODO actuator-level gravity compensation, skip if added as passive force
 

--- a/mujoco/mjx/_src/forward.py
+++ b/mujoco/mjx/_src/forward.py
@@ -531,8 +531,8 @@ def fwd_actuation(m: Model, d: Data):
         actuator_force: array3df,
       ):
         worldid, nodeid = wp.tid()
-        offset_nu = m.qderiv_implicit_offset_nu[leveladr + nodeid]
-        offset_nv = m.qderiv_implicit_offset_nv[leveladr + nodeid]
+        offset_nu = m.actuator_moment_offset_nu[leveladr + nodeid]
+        offset_nv = m.actuator_moment_offset_nv[leveladr + nodeid]
 
         actuator_moment_tile = wp.tile_load(
           d.actuator_moment[worldid],
@@ -560,14 +560,14 @@ def fwd_actuation(m: Model, d: Data):
         block_dim=32,
       )
 
-    qderiv_tilesize_nu = m.qderiv_implicit_tilesize_nu.numpy()
-    qderiv_tilesize_nv = m.qderiv_implicit_tilesize_nv.numpy()
-    qderiv_tileadr = m.qderiv_implicit_tileadr.numpy()
+    qderiv_tilesize_nu = m.actuator_moment_tilesize_nu.numpy()
+    qderiv_tilesize_nv = m.actuator_moment_tilesize_nv.numpy()
+    qderiv_tileadr = m.actuator_moment_tileadr.numpy()
 
     for i in range(len(qderiv_tileadr)):
       beg = qderiv_tileadr[i]
       end = (
-        m.qderiv_implicit_tileadr.shape[0]
+        m.actuator_moment_tileadr.shape[0]
         if i == len(qderiv_tileadr) - 1
         else qderiv_tileadr[i + 1]
       )


### PR DESCRIPTION
tile operations with 1 humanoid:
```
mjx-testspeed --function=fwd_actuation --is_sparse=False --mjcf=humanoid/humanoid.xml --batch_size=8192
```
```
Summary for 8192 parallel rollouts

 Total JIT time: 0.10 s
 Total simulation time: 0.11 s
 Total steps per second: 73,175,809
 Total realtime factor: 365,879.04 x
 Total time per step: 13.67 ns
```

current code with 1 humanoid:
```
mjx-testspeed --function=fwd_actuation --is_sparse=True --mjcf=humanoid/humanoid.xml --batch_size=8192
```
```
Summary for 8192 parallel rollouts

 Total JIT time: 0.00 s
 Total simulation time: 0.06 s
 Total steps per second: 133,237,216
 Total realtime factor: 666,186.08 x
 Total time per step: 7.51 ns
```

tile operations with n_humanoids (n=3):
```
mjx-testspeed --function=fwd_actuation --is_sparse=False --mjcf=humanoid/n_humanoids.xml --batch_size=8192
```
```
Summary for 8192 parallel rollouts

 Total JIT time: 0.09 s
 Total simulation time: 0.14 s
 Total steps per second: 59,389,431
 Total realtime factor: 296,947.16 x
 Total time per step: 16.84 ns
```

current code with n_humanoids (n=3):
```
mjx-testspeed --function=fwd_actuation --is_sparse=True --mjcf=humanoid/n_humanoids.xml --batch_size=8192
```
```
Summary for 8192 parallel rollouts

 Total JIT time: 0.00 s
 Total simulation time: 0.45 s
 Total steps per second: 18,316,371
 Total realtime factor: 91,581.85 x
 Total time per step: 54.60 ns
```