### PR TITLE
n^2 broadphase

### DIFF
--- a/mujoco/mjx/__init__.py
+++ b/mujoco/mjx/__init__.py
@@ -16,6 +16,7 @@
 """Public API for MJX."""
 
 from ._src.collision_driver import broadphase as broadphase
+from ._src.collision_driver import broadphase_sweep_and_prune as broadphase_sweep_and_prune
 from ._src.collision_driver import collision as collision
 from ._src.collision_driver import nxn_broadphase as nxn_broadphase
 from ._src.constraint import make_constraint as make_constraint

--- a/mujoco/mjx/__init__.py
+++ b/mujoco/mjx/__init__.py
@@ -16,7 +16,9 @@
 """Public API for MJX."""
 
 from ._src.collision_driver import broadphase as broadphase
-from ._src.collision_driver import broadphase_sweep_and_prune as broadphase_sweep_and_prune
+from ._src.collision_driver import (
+  broadphase_sweep_and_prune as broadphase_sweep_and_prune,
+)
 from ._src.collision_driver import collision as collision
 from ._src.collision_driver import nxn_broadphase as nxn_broadphase
 from ._src.constraint import make_constraint as make_constraint

--- a/mujoco/mjx/__init__.py
+++ b/mujoco/mjx/__init__.py
@@ -16,6 +16,7 @@
 """Public API for MJX."""
 
 from ._src.collision_driver import broad_phase as broad_phase
+from ._src.collision_driver import nxn_broadphase as nxn_broadphase
 from ._src.constraint import make_constraint as make_constraint
 from ._src.forward import euler as euler
 from ._src.forward import forward as forward

--- a/mujoco/mjx/_src/broad_phase_test.py
+++ b/mujoco/mjx/_src/broad_phase_test.py
@@ -231,53 +231,25 @@ class BroadPhaseTest(parameterized.TestCase):
     # one world and zero collisions
     mjm, _, m, d0 = test_util.fixture("broadphase.xml", keyframe=0)
     collision_driver.nxn_broadphase(m, d0)
-    np.testing.assert_allclose(d0.nbroadphase_total.numpy()[0], 0)
+    np.testing.assert_allclose(d0.broadphase_result_count.numpy()[0], 0)
 
     # one world and one collision
     _, mjd1, _, d1 = test_util.fixture("broadphase.xml", keyframe=1)
     collision_driver.nxn_broadphase(m, d1)
-    np.testing.assert_allclose(d1.nbroadphase_total.numpy()[0], 1)
-    np.testing.assert_allclose(d1.broadphase_geom1.numpy()[0], 0)
-    np.testing.assert_allclose(d1.broadphase_geom2.numpy()[0], 1)
-    np.testing.assert_allclose(
-      d1.broadphase_type1.numpy()[0], int(mujoco.mjtGeom.mjGEOM_SPHERE)
-    )
-    np.testing.assert_allclose(
-      d1.broadphase_type2.numpy()[0], int(mujoco.mjtGeom.mjGEOM_SPHERE)
-    )
-    np.testing.assert_allclose(d1.broadphase_worldid.numpy()[0], 0)
+    np.testing.assert_allclose(d1.broadphase_result_count.numpy()[0], 1)
+    np.testing.assert_allclose(d1.broadphase_pairs.numpy()[0, 0][0], 0)
+    np.testing.assert_allclose(d1.broadphase_pairs.numpy()[0, 0][1], 1)
 
     # one world and three collisions
     _, mjd2, _, d2 = test_util.fixture("broadphase.xml", keyframe=2)
     collision_driver.nxn_broadphase(m, d2)
-    np.testing.assert_allclose(d2.nbroadphase_total.numpy()[0], 3)
-    np.testing.assert_allclose(d2.broadphase_geom1.numpy()[0], 0)
-    np.testing.assert_allclose(d2.broadphase_geom2.numpy()[0], 1)
-    np.testing.assert_allclose(
-      d2.broadphase_type1.numpy()[0], int(mujoco.mjtGeom.mjGEOM_SPHERE)
-    )
-    np.testing.assert_allclose(
-      d2.broadphase_type2.numpy()[0], int(mujoco.mjtGeom.mjGEOM_SPHERE)
-    )
-    np.testing.assert_allclose(d2.broadphase_worldid.numpy()[0], 0)
-    np.testing.assert_allclose(d2.broadphase_geom1.numpy()[1], 0)
-    np.testing.assert_allclose(d2.broadphase_geom2.numpy()[1], 2)
-    np.testing.assert_allclose(
-      d2.broadphase_type1.numpy()[1], int(mujoco.mjtGeom.mjGEOM_SPHERE)
-    )
-    np.testing.assert_allclose(
-      d2.broadphase_type2.numpy()[1], int(mujoco.mjtGeom.mjGEOM_CAPSULE)
-    )
-    np.testing.assert_allclose(d2.broadphase_worldid.numpy()[1], 0)
-    np.testing.assert_allclose(d2.broadphase_geom1.numpy()[2], 1)
-    np.testing.assert_allclose(d2.broadphase_geom2.numpy()[2], 2)
-    np.testing.assert_allclose(
-      d2.broadphase_type1.numpy()[2], int(mujoco.mjtGeom.mjGEOM_SPHERE)
-    )
-    np.testing.assert_allclose(
-      d2.broadphase_type2.numpy()[2], int(mujoco.mjtGeom.mjGEOM_CAPSULE)
-    )
-    np.testing.assert_allclose(d2.broadphase_worldid.numpy()[2], 0)
+    np.testing.assert_allclose(d2.broadphase_result_count.numpy()[0], 3)
+    np.testing.assert_allclose(d2.broadphase_pairs.numpy()[0, 0][0], 0)
+    np.testing.assert_allclose(d2.broadphase_pairs.numpy()[0, 0][1], 1)
+    np.testing.assert_allclose(d2.broadphase_pairs.numpy()[0, 1][0], 0)
+    np.testing.assert_allclose(d2.broadphase_pairs.numpy()[0, 1][1], 2)
+    np.testing.assert_allclose(d2.broadphase_pairs.numpy()[0, 2][0], 1)
+    np.testing.assert_allclose(d2.broadphase_pairs.numpy()[0, 2][1], 2)
 
     # two worlds and four collisions
     d3 = mjx.make_data(mjm, nworld=2)
@@ -289,63 +261,29 @@ class BroadPhaseTest(parameterized.TestCase):
     )
 
     collision_driver.nxn_broadphase(m, d3)
-    np.testing.assert_allclose(d3.nbroadphase_total.numpy()[0], 4)
-    np.testing.assert_allclose(d3.broadphase_geom1.numpy()[0], 0)
-    np.testing.assert_allclose(d3.broadphase_geom2.numpy()[0], 1)
-    np.testing.assert_allclose(
-      d3.broadphase_type1.numpy()[0], int(mujoco.mjtGeom.mjGEOM_SPHERE)
-    )
-    np.testing.assert_allclose(
-      d3.broadphase_type2.numpy()[0], int(mujoco.mjtGeom.mjGEOM_SPHERE)
-    )
-    np.testing.assert_allclose(d3.broadphase_worldid.numpy()[0], 0)
-    np.testing.assert_allclose(d3.broadphase_geom1.numpy()[1], 0)
-    np.testing.assert_allclose(d3.broadphase_geom2.numpy()[1], 1)
-    np.testing.assert_allclose(
-      d3.broadphase_type1.numpy()[1], int(mujoco.mjtGeom.mjGEOM_SPHERE)
-    )
-    np.testing.assert_allclose(
-      d3.broadphase_type2.numpy()[1], int(mujoco.mjtGeom.mjGEOM_SPHERE)
-    )
-    np.testing.assert_allclose(d3.broadphase_worldid.numpy()[1], 1)
-    np.testing.assert_allclose(d3.broadphase_geom1.numpy()[2], 0)
-    np.testing.assert_allclose(d3.broadphase_geom2.numpy()[2], 2)
-    np.testing.assert_allclose(
-      d3.broadphase_type1.numpy()[2], int(mujoco.mjtGeom.mjGEOM_SPHERE)
-    )
-    np.testing.assert_allclose(
-      d3.broadphase_type2.numpy()[2], int(mujoco.mjtGeom.mjGEOM_CAPSULE)
-    )
-    np.testing.assert_allclose(d3.broadphase_worldid.numpy()[2], 1)
-    np.testing.assert_allclose(d3.broadphase_geom1.numpy()[3], 1)
-    np.testing.assert_allclose(d3.broadphase_geom2.numpy()[3], 2)
-    np.testing.assert_allclose(
-      d3.broadphase_type1.numpy()[3], int(mujoco.mjtGeom.mjGEOM_SPHERE)
-    )
-    np.testing.assert_allclose(
-      d3.broadphase_type2.numpy()[3], int(mujoco.mjtGeom.mjGEOM_CAPSULE)
-    )
-    np.testing.assert_allclose(d3.broadphase_worldid.numpy()[3], 1)
+    np.testing.assert_allclose(d3.broadphase_result_count.numpy()[0], 4)
+    np.testing.assert_allclose(d3.broadphase_pairs.numpy()[0, 0][0], 0)
+    np.testing.assert_allclose(d3.broadphase_pairs.numpy()[0, 0][1], 1)
+    np.testing.assert_allclose(d3.broadphase_pairs.numpy()[1, 1][0], 0)
+    np.testing.assert_allclose(d3.broadphase_pairs.numpy()[1, 1][1], 1)
+    np.testing.assert_allclose(d3.broadphase_pairs.numpy()[1, 2][0], 0)
+    np.testing.assert_allclose(d3.broadphase_pairs.numpy()[1, 2][1], 2)
+    np.testing.assert_allclose(d3.broadphase_pairs.numpy()[1, 3][0], 1)
+    np.testing.assert_allclose(d3.broadphase_pairs.numpy()[1, 3][1], 2)
 
     # one world and zero collisions: contype and conaffinity incompatibility
     _, _, m4, d4 = test_util.fixture("broadphase.xml", keyframe=1)
     m4.geom_contype = wp.array(np.array([0, 0, 0]), dtype=wp.int32)
     m4.geom_conaffinity = wp.array(np.array([1, 1, 1]), dtype=wp.int32)
     collision_driver.nxn_broadphase(m4, d4)
-    np.testing.assert_allclose(d4.nbroadphase_total.numpy()[0], 0)
+    np.testing.assert_allclose(d4.broadphase_result_count.numpy()[0], 0)
 
     # one world and one collision: geomtype ordering
     _, _, _, d5 = test_util.fixture("broadphase.xml", keyframe=3)
     collision_driver.nxn_broadphase(m, d5)
-    np.testing.assert_allclose(d5.nbroadphase_total.numpy()[0], 1)
-    np.testing.assert_allclose(d5.broadphase_geom1.numpy()[0], 3)
-    np.testing.assert_allclose(d5.broadphase_geom2.numpy()[0], 2)
-    np.testing.assert_allclose(
-      d5.broadphase_type1.numpy()[0], int(mujoco.mjtGeom.mjGEOM_SPHERE)
-    )
-    np.testing.assert_allclose(
-      d5.broadphase_type2.numpy()[0], int(mujoco.mjtGeom.mjGEOM_CAPSULE)
-    )
+    np.testing.assert_allclose(d5.broadphase_result_count.numpy()[0], 1)
+    np.testing.assert_allclose(d5.broadphase_pairs.numpy()[0, 0][0], 3)
+    np.testing.assert_allclose(d5.broadphase_pairs.numpy()[0, 0][1], 2)
 
     # TODO(team): test margin
 

--- a/mujoco/mjx/_src/broad_phase_test.py
+++ b/mujoco/mjx/_src/broad_phase_test.py
@@ -23,9 +23,9 @@ from absl.testing import absltest, parameterized
 
 from . import test_util
 from . import collision_driver
+from .collision_driver import AABB
 
 BoxType = wp.types.matrix(shape=(2, 3), dtype=wp.float32)
-from .collision_driver import AABB
 
 
 def transform_aabb(aabb_pos, aabb_size, pos: wp.vec3, ori: wp.mat33) -> AABB:

--- a/mujoco/mjx/_src/broad_phase_test.py
+++ b/mujoco/mjx/_src/broad_phase_test.py
@@ -346,7 +346,8 @@ class BroadPhaseTest(parameterized.TestCase):
     np.testing.assert_allclose(
       d5.broadphase_type2.numpy()[0], int(mujoco.mjtGeom.mjGEOM_CAPSULE)
     )
-    return
+
+    # TODO(team): test margin
 
   def test_broadphase_simple(self):
     """Tests the broadphase"""

--- a/mujoco/mjx/_src/broad_phase_test.py
+++ b/mujoco/mjx/_src/broad_phase_test.py
@@ -182,7 +182,7 @@ class BroadPhaseTest(parameterized.TestCase):
     mx = mjx.put_model(m)
     dx = mjx.put_data(m, d)
 
-    mjx.broadphase(mx, dx)
+    mjx.broadphase_sweep_and_prune(mx, dx)
 
     m = mx
     d = dx
@@ -198,7 +198,7 @@ class BroadPhaseTest(parameterized.TestCase):
       d.nworld, m.ngeom, aabbs, pos, rot, m.geom_bodyid.numpy()
     )
 
-    mjx.broadphase(m, d)
+    mjx.broadphase_sweep_and_prune(m, d)
 
     result = d.broadphase_pairs
     broadphase_result_count = d.broadphase_result_count
@@ -221,7 +221,11 @@ class BroadPhaseTest(parameterized.TestCase):
         pair = result_np[world_idx][i]
 
         # Convert pair to tuple for comparison
-        pair_tuple = (int(pair[0]), int(pair[1]))
+        # TODO(team): confirm ordering is correct
+        if pair[0] > pair[1]:
+          pair_tuple = (int(pair[1]), int(pair[0]))
+        else:
+          pair_tuple = (int(pair[0]), int(pair[1]))
         assert pair_tuple in list, (
           f"Collision pair {pair_tuple} not found in brute force results"
         )
@@ -334,7 +338,7 @@ class BroadPhaseTest(parameterized.TestCase):
     mx = mjx.put_model(m)
     dx = mjx.put_data(m, d)
 
-    mjx.broadphase(mx, dx)
+    mjx.broadphase_sweep_and_prune(mx, dx)
 
     assert dx.broadphase_result_count.numpy()[0] == 8
 

--- a/mujoco/mjx/_src/collision_driver.py
+++ b/mujoco/mjx/_src/collision_driver.py
@@ -523,8 +523,6 @@ def nxn_broadphase(m: Model, d: Data):
       + (m.ngeom - geom1) * ((m.ngeom - geom1) - 1) // 2
     )
 
-    geomtype1 = m.geom_type[geom1]
-    geomtype2 = m.geom_type[geom2]
     margin1 = m.geom_margin[geom1]
     margin2 = m.geom_margin[geom2]
     pos1 = d.geom_xpos[worldid, geom1]

--- a/mujoco/mjx/_src/collision_driver.py
+++ b/mujoco/mjx/_src/collision_driver.py
@@ -429,7 +429,7 @@ def nxn_broadphase(m: Model, d: Data):
     weld_parentid1 = m.body_weldid[m.body_parentid[weldid1]]
     weld_parentid2 = m.body_weldid[m.body_parentid[weldid2]]
 
-    self_collision = (weldid1 == weldid2)
+    self_collision = weldid1 == weldid2
     parent_child_collision = (
       filterparent
       and (weldid1 != 0)

--- a/mujoco/mjx/_src/collision_driver.py
+++ b/mujoco/mjx/_src/collision_driver.py
@@ -51,7 +51,7 @@ def _geom_filter(m: Model, geom1: int, geom2: int, filterparent: bool) -> bool:
 
 
 @wp.func
-def _geom_pair(m: Model, geom1: int, geom2: int):
+def _geom_pair(m: Model, geom1: int, geom2: int) -> wp.vec2i:
   if m.geom_type[geom1] > m.geom_type[geom2]:
     return wp.vec2i(geom2, geom1)
   else:

--- a/mujoco/mjx/_src/collision_driver.py
+++ b/mujoco/mjx/_src/collision_driver.py
@@ -498,6 +498,8 @@ def nxn_broadphase(m: Model, d: Data):
     conaffinity2 = m.geom_conaffinity[geom2]
     geomtype1 = m.geom_type[geom1]
     geomtype2 = m.geom_type[geom2]
+    margin1 = m.geom_margin[geom1]
+    margin2 = m.geom_margin[geom2]
     pos1 = d.geom_xpos[worldid, geom1]
     pos2 = d.geom_xpos[worldid, geom2]
     size1 = m.geom_rbound[geom1]
@@ -516,8 +518,11 @@ def nxn_broadphase(m: Model, d: Data):
     )
     mask = (contype1 and conaffinity2) or (contype2 and conaffinity1)
 
+    bound = size1 + size2 + wp.max(margin1, margin2)
+    dif = pos2 - pos1
+    
     if (
-      (wp.norm_l2(pos2 - pos1) <= (size1 + size2))
+      (wp.dot(dif, dif) <= bound * bound)
       and mask
       and (not self_collision)
       and (not parent_child_collision)

--- a/mujoco/mjx/_src/collision_driver.py
+++ b/mujoco/mjx/_src/collision_driver.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 
-import mujoco
 import warp as wp
 
 from .types import Model
@@ -464,7 +463,7 @@ def broadphase_sweep_and_prune(m: Model, d: Data):
 
 
 def nxn_broadphase(m: Model, d: Data):
-  filterparent = not (m.opt.disableflags & mujoco.mjtDisableBit.mjDSBL_FILTERPARENT)
+  filterparent = not (m.opt.disableflags & DisableBit.FILTERPARENT.value)
 
   d.broadphase_result_count.zero_()
 
@@ -512,8 +511,8 @@ def nxn_broadphase(m: Model, d: Data):
 
 
 def broadphase(m: Model, d: Data):
-  # broadphase collision 
-  
+  # broadphase collision
+
   # TODO(team): determine ngeom to switch from n^2 to sap
   if m.ngeom <= 100:
     nxn_broadphase(m, d)

--- a/mujoco/mjx/_src/io.py
+++ b/mujoco/mjx/_src/io.py
@@ -213,6 +213,7 @@ def put_model(mjm: mujoco.MjModel) -> types.Model:
   m.body_jntnum = wp.array(mjm.body_jntnum, dtype=wp.int32, ndim=1)
   m.body_parentid = wp.array(mjm.body_parentid, dtype=wp.int32, ndim=1)
   m.body_mocapid = wp.array(mjm.body_mocapid, dtype=wp.int32, ndim=1)
+  m.body_weldid = wp.array(mjm.body_weldid, dtype=wp.int32, ndim=1)
   m.body_pos = wp.array(mjm.body_pos, dtype=wp.vec3, ndim=1)
   m.body_quat = wp.array(mjm.body_quat, dtype=wp.quat, ndim=1)
   m.body_ipos = wp.array(mjm.body_ipos, dtype=wp.vec3, ndim=1)
@@ -239,8 +240,12 @@ def put_model(mjm: mujoco.MjModel) -> types.Model:
   m.jnt_actfrclimited = wp.array(mjm.jnt_actfrclimited, dtype=wp.bool, ndim=1)
   m.jnt_actfrcrange = wp.array(mjm.jnt_actfrcrange, dtype=wp.vec2, ndim=1)
   m.geom_bodyid = wp.array(mjm.geom_bodyid, dtype=wp.int32, ndim=1)
+  m.geom_conaffinity = wp.array(mjm.geom_conaffinity, dtype=wp.int32, ndim=1)
+  m.geom_contype = wp.array(mjm.geom_contype, dtype=wp.int32, ndim=1)
   m.geom_pos = wp.array(mjm.geom_pos, dtype=wp.vec3, ndim=1)
   m.geom_quat = wp.array(mjm.geom_quat, dtype=wp.quat, ndim=1)
+  m.geom_type = wp.array(mjm.geom_type, dtype=wp.int32, ndim=1)
+  m.geom_rbound = wp.array(mjm.geom_rbound, dtype=wp.float32, ndim=1)
   m.site_pos = wp.array(mjm.site_pos, dtype=wp.vec3, ndim=1)
   m.site_quat = wp.array(mjm.site_quat, dtype=wp.quat, ndim=1)
   m.dof_bodyid = wp.array(mjm.dof_bodyid, dtype=wp.int32, ndim=1)
@@ -370,6 +375,13 @@ def make_data(
   d.efc_worldid = wp.zeros((njmax,), dtype=wp.int32)
 
   d.xfrc_applied = wp.zeros((nworld, mjm.nbody), dtype=wp.spatial_vector)
+
+  d.nbroadphase_total = wp.zeros((1,), dtype=wp.int32, ndim=1)
+  d.broadphase_geom1 = wp.zeros((nconmax,), dtype=wp.int32)
+  d.broadphase_geom2 = wp.zeros((nconmax,), dtype=wp.int32)
+  d.broadphase_type1 = wp.zeros((nconmax,), dtype=wp.int32)
+  d.broadphase_type2 = wp.zeros((nconmax,), dtype=wp.int32)
+  d.broadphase_worldid = wp.zeros((nconmax,), dtype=wp.int32)
 
   # internal tmp arrays
   d.qfrc_integration = wp.zeros((nworld, mjm.nv), dtype=wp.float32)
@@ -595,6 +607,14 @@ def put_data(
   d.contact.worldid = wp.array(con_worldid, dtype=wp.int32, ndim=1)
 
   d.xfrc_applied = wp.array(tile(mjd.xfrc_applied), dtype=wp.spatial_vector, ndim=2)
+
+  d.nbroadphase_total = wp.zeros((1,), dtype=wp.int32)
+  d.broadphase_geom1 = wp.zeros((nconmax,), dtype=wp.int32)
+  d.broadphase_geom2 = wp.zeros((nconmax,), dtype=wp.int32)
+  d.broadphase_type1 = wp.zeros((nconmax,), dtype=wp.int32)
+  d.broadphase_type2 = wp.zeros((nconmax,), dtype=wp.int32)
+  d.broadphase_worldid = wp.zeros((nconmax,), dtype=wp.int32)
+
   # internal tmp arrays
   d.qfrc_integration = wp.zeros((nworld, mjm.nv), dtype=wp.float32)
   d.qacc_integration = wp.zeros((nworld, mjm.nv), dtype=wp.float32)

--- a/mujoco/mjx/_src/io.py
+++ b/mujoco/mjx/_src/io.py
@@ -250,7 +250,6 @@ def put_model(mjm: mujoco.MjModel) -> types.Model:
   m.geom_contype = wp.array(mjm.geom_contype, dtype=wp.int32, ndim=1)
   m.geom_pos = wp.array(mjm.geom_pos, dtype=wp.vec3, ndim=1)
   m.geom_quat = wp.array(mjm.geom_quat, dtype=wp.quat, ndim=1)
-  m.geom_type = wp.array(mjm.geom_type, dtype=wp.int32, ndim=1)
   m.geom_size = wp.array(mjm.geom_size, dtype=wp.vec3, ndim=1)
   m.geom_priority = wp.array(mjm.geom_priority, dtype=wp.int32, ndim=1)
   m.geom_solmix = wp.array(mjm.geom_solmix, dtype=wp.float32, ndim=1)
@@ -529,7 +528,6 @@ def put_data(
   d.qfrc_smooth = wp.array(tile(mjd.qfrc_smooth), dtype=wp.float32, ndim=2)
   d.qfrc_constraint = wp.array(tile(mjd.qfrc_constraint), dtype=wp.float32, ndim=2)
   d.qacc_smooth = wp.array(tile(mjd.qacc_smooth), dtype=wp.float32, ndim=2)
-  d.qfrc_constraint = wp.array(tile(mjd.qfrc_constraint), dtype=wp.float32, ndim=2)
   d.act = wp.array(tile(mjd.act), dtype=wp.float32, ndim=2)
   d.act_dot = wp.array(tile(mjd.act_dot), dtype=wp.float32, ndim=2)
 

--- a/mujoco/mjx/_src/io.py
+++ b/mujoco/mjx/_src/io.py
@@ -225,7 +225,6 @@ def put_model(mjm: mujoco.MjModel) -> types.Model:
   m.body_invweight0 = wp.array(mjm.body_invweight0, dtype=wp.float32, ndim=2)
   m.body_geomnum = wp.array(mjm.body_geomnum, dtype=wp.int32, ndim=1)
   m.body_geomadr = wp.array(mjm.body_geomadr, dtype=wp.int32, ndim=1)
-  m.body_weldid = wp.array(mjm.body_weldid, dtype=wp.int32, ndim=1)
   m.body_contype = wp.array(mjm.body_contype, dtype=wp.int32, ndim=1)
   m.body_conaffinity = wp.array(mjm.body_conaffinity, dtype=wp.int32, ndim=1)
   m.jnt_bodyid = wp.array(mjm.jnt_bodyid, dtype=wp.int32, ndim=1)

--- a/mujoco/mjx/_src/io.py
+++ b/mujoco/mjx/_src/io.py
@@ -395,13 +395,6 @@ def make_data(
 
   d.xfrc_applied = wp.zeros((nworld, mjm.nbody), dtype=wp.spatial_vector)
 
-  d.nbroadphase_total = wp.zeros((1,), dtype=wp.int32, ndim=1)
-  d.broadphase_geom1 = wp.zeros((nconmax,), dtype=wp.int32)
-  d.broadphase_geom2 = wp.zeros((nconmax,), dtype=wp.int32)
-  d.broadphase_type1 = wp.zeros((nconmax,), dtype=wp.int32)
-  d.broadphase_type2 = wp.zeros((nconmax,), dtype=wp.int32)
-  d.broadphase_worldid = wp.zeros((nconmax,), dtype=wp.int32)
-
   # internal tmp arrays
   d.qfrc_integration = wp.zeros((nworld, mjm.nv), dtype=wp.float32)
   d.qacc_integration = wp.zeros((nworld, mjm.nv), dtype=wp.float32)
@@ -630,13 +623,6 @@ def put_data(
   d.contact.worldid = wp.array(con_worldid, dtype=wp.int32, ndim=1)
 
   d.xfrc_applied = wp.array(tile(mjd.xfrc_applied), dtype=wp.spatial_vector, ndim=2)
-
-  d.nbroadphase_total = wp.zeros((1,), dtype=wp.int32)
-  d.broadphase_geom1 = wp.zeros((nconmax,), dtype=wp.int32)
-  d.broadphase_geom2 = wp.zeros((nconmax,), dtype=wp.int32)
-  d.broadphase_type1 = wp.zeros((nconmax,), dtype=wp.int32)
-  d.broadphase_type2 = wp.zeros((nconmax,), dtype=wp.int32)
-  d.broadphase_worldid = wp.zeros((nconmax,), dtype=wp.int32)
 
   # internal tmp arrays
   d.qfrc_integration = wp.zeros((nworld, mjm.nv), dtype=wp.float32)

--- a/mujoco/mjx/_src/support_test.py
+++ b/mujoco/mjx/_src/support_test.py
@@ -83,12 +83,13 @@ class SupportTest(parameterized.TestCase):
     md = make_data(mjm)
 
     # same number of fields
-    assert(len(d.__dict__) == len(md.__dict__))
+    assert len(d.__dict__) == len(md.__dict__)
 
     # test shapes for all arrays
     for attr, val in md.__dict__.items():
-      if (type(val) == wp.array):
-        assert(val.shape == getattr(d, attr).shape)
+      if type(val) == wp.array:
+        assert val.shape == getattr(d, attr).shape
+
 
 if __name__ == "__main__":
   wp.init()

--- a/mujoco/mjx/_src/types.py
+++ b/mujoco/mjx/_src/types.py
@@ -377,7 +377,7 @@ class Data:
   broadphase_geom2: wp.array(dtype=wp.int32, ndim=1)  # warp only
   broadphase_type1: wp.array(dtype=wp.int32, ndim=1)  # warp only
   broadphase_type2: wp.array(dtype=wp.int32, ndim=1)  # warp only
-  broadphase_worldid: wp.array(dtype=wp.int32, ndim=1) # warp only
+  broadphase_worldid: wp.array(dtype=wp.int32, ndim=1)  # warp only
 
   # temp arrays
   qfrc_integration: wp.array(dtype=wp.float32, ndim=2)

--- a/mujoco/mjx/_src/types.py
+++ b/mujoco/mjx/_src/types.py
@@ -420,12 +420,6 @@ class Data:
   efc_worldid: wp.array(dtype=wp.int32, ndim=1)  # warp only
   xfrc_applied: wp.array(dtype=wp.spatial_vector, ndim=2)
   contact: Contact
-  nbroadphase_total: wp.array(dtype=wp.int32, ndim=1)  # warp only
-  broadphase_geom1: wp.array(dtype=wp.int32, ndim=1)  # warp only
-  broadphase_geom2: wp.array(dtype=wp.int32, ndim=1)  # warp only
-  broadphase_type1: wp.array(dtype=wp.int32, ndim=1)  # warp only
-  broadphase_type2: wp.array(dtype=wp.int32, ndim=1)  # warp only
-  broadphase_worldid: wp.array(dtype=wp.int32, ndim=1)  # warp only
 
   # temp arrays
   qfrc_integration: wp.array(dtype=wp.float32, ndim=2)

--- a/mujoco/mjx/_src/types.py
+++ b/mujoco/mjx/_src/types.py
@@ -255,8 +255,12 @@ class Model:
   jnt_actfrclimited: wp.array(dtype=wp.bool, ndim=1)
   jnt_actfrcrange: wp.array(dtype=wp.vec2, ndim=1)
   geom_bodyid: wp.array(dtype=wp.int32, ndim=1)
+  geom_conaffinity: wp.array(dtype=wp.int32, ndim=1)
+  geom_contype: wp.array(dtype=wp.int32, ndim=1)
   geom_pos: wp.array(dtype=wp.vec3, ndim=1)
   geom_quat: wp.array(dtype=wp.quat, ndim=1)
+  geom_rbound: wp.array(dtype=wp.float32, ndim=1)
+  geom_type: wp.array(dtype=wp.int32, ndim=1)
   site_pos: wp.array(dtype=wp.vec3, ndim=1)
   site_quat: wp.array(dtype=wp.quat, ndim=1)
   site_bodyid: wp.array(dtype=wp.int32, ndim=1)
@@ -368,6 +372,12 @@ class Data:
   efc_worldid: wp.array(dtype=wp.int32, ndim=1)  # warp only
   xfrc_applied: wp.array(dtype=wp.spatial_vector, ndim=2)
   contact: Contact
+  nbroadphase_total: wp.array(dtype=wp.int32, ndim=1)  # warp only
+  broadphase_geom1: wp.array(dtype=wp.int32, ndim=1)  # warp only
+  broadphase_geom2: wp.array(dtype=wp.int32, ndim=1)  # warp only
+  broadphase_type1: wp.array(dtype=wp.int32, ndim=1)  # warp only
+  broadphase_type2: wp.array(dtype=wp.int32, ndim=1)  # warp only
+  broadphase_worldid: wp.array(dtype=wp.int32, ndim=1) # warp only
 
   # temp arrays
   qfrc_integration: wp.array(dtype=wp.float32, ndim=2)

--- a/mujoco/mjx/_src/types.py
+++ b/mujoco/mjx/_src/types.py
@@ -294,7 +294,6 @@ class Model:
   geom_contype: wp.array(dtype=wp.int32, ndim=1)
   geom_pos: wp.array(dtype=wp.vec3, ndim=1)
   geom_quat: wp.array(dtype=wp.quat, ndim=1)
-  geom_type: wp.array(dtype=wp.int32, ndim=1)
   geom_size: wp.array(dtype=wp.vec3, ndim=1)
   geom_priority: wp.array(dtype=wp.int32, ndim=1)
   geom_solmix: wp.array(dtype=wp.float32, ndim=1)
@@ -367,7 +366,6 @@ class Data:
   qpos: wp.array(dtype=wp.float32, ndim=2)
   qvel: wp.array(dtype=wp.float32, ndim=2)
   qacc_warmstart: wp.array(dtype=wp.float32, ndim=2)
-  qfrc_applied: wp.array(dtype=wp.float32, ndim=2)
   ncon: wp.array(dtype=wp.int32, ndim=1)
   nl: int
   nefc: wp.array(dtype=wp.int32, ndim=1)
@@ -410,7 +408,6 @@ class Data:
   qfrc_actuator: wp.array(dtype=wp.float32, ndim=2)
   qfrc_smooth: wp.array(dtype=wp.float32, ndim=2)
   qacc_smooth: wp.array(dtype=wp.float32, ndim=2)
-  qfrc_constraint: wp.array(dtype=wp.float32, ndim=2)
   efc_J: wp.array(dtype=wp.float32, ndim=2)
   efc_D: wp.array(dtype=wp.float32, ndim=1)
   efc_pos: wp.array(dtype=wp.float32, ndim=1)

--- a/mujoco/mjx/test_data/broadphase.xml
+++ b/mujoco/mjx/test_data/broadphase.xml
@@ -1,0 +1,59 @@
+<mujoco>
+  <worldbody>
+    <body>
+      <freejoint/>
+      <geom type="sphere" size="0.1"/>
+    </body>
+    <body>
+      <freejoint/>
+      <geom type="sphere" size="0.1"/>
+    </body>
+    <body>
+      <freejoint/>
+      <geom type="capsule" size="0.1 0.1"/>
+    </body>
+    <body>
+      <freejoint/>
+      <geom type="sphere" size="0.1"/>
+    </body>
+
+    <body>
+      <freejoint/>
+      <!-- self collision -->
+      <geom type="sphere" size="0.1"/>
+      <geom type="sphere" size="0.1"/>
+      <!-- parent-child self collision -->
+      <body>
+        <geom type="sphere" size="0.1"/>
+        <joint type="hinge"/>
+      </body>
+    </body>
+  </worldbody>
+
+  <keyframe>
+    <key qpos='0 0 0 1 0 0 0
+               1 0 0 1 0 0 0
+               2 0 0 1 0 0 0
+               3 0 0 1 0 0 0
+               4 0 0 1 0 0 0
+               0'/>
+    <key qpos='0 0 0 1 0 0 0
+               .05 0 0 1 0 0 0
+               2 0 0 1 0 0 0
+               3 0 0 1 0 0 0
+               4 0 0 1 0 0 0 
+               0'/>
+    <key qpos='0 0 0 1 0 0 0
+               .01 0 0 1 0 0 0
+               .02 0 0 1 0 0 0
+               3 0 0 1 0 0 0
+               4 0 0 1 0 0 0 
+               0'/>
+    <key qpos='0 0 0 1 0 0 0
+               1 0 0 1 0 0 0
+               2 0 0 1 0 0 0
+               2 0 0 1 0 0 0
+               4 0 0 1 0 0 0 
+               0'/>
+  </keyframe>
+</mujoco>


### PR DESCRIPTION
```
mjx-testspeed --function=nxn_broadphase --mjcf=humanoid/humanoid.xml --batch_size=8192
```
```
Summary for 8192 parallel rollouts

 Total JIT time: 0.01 s
 Total simulation time: 0.06 s
 Total steps per second: 140,677,877
 Total realtime factor: 703,389.38 x
 Total time per step: 7.11 ns
```