### PR TITLE
Avoid compiling/loading the same kernel over and over again

### DIFF
--- a/mujoco/mjx/_src/forward_test.py
+++ b/mujoco/mjx/_src/forward_test.py
@@ -145,21 +145,11 @@ class ForwardTest(absltest.TestCase):
     np.testing.assert_allclose(d.qvel.numpy()[0], 1 + mjm.opt.timestep)
 
   def test_stepping(self):
-    path = epath.resource_path("mujoco.mjx") / "test_data/pendula.xml"
-    mjm = mujoco.MjModel.from_xml_path(path.as_posix())
-    self.assertTrue((mjm.dof_damping > 0).any())
+    _, mjd, m, d = self._load("humanoid/humanoid.xml")
 
-    mjd = mujoco.MjData(mjm)
-    mjd.qvel[:] = 1.0
-    mjd.qacc[:] = 1.0
-    mujoco.mj_forward(mjm, mjd)
-
-    m = mjx.put_model(mjm)
-    d = mjx.put_data(mjm, mjd)
-
-    for i in range(100):
+    for i in range(10):
       mjx.step(m, d)
-    pass
+      print(i)
 
 
 class ImplicitIntegratorTest(parameterized.TestCase):

--- a/mujoco/mjx/_src/forward_test.py
+++ b/mujoco/mjx/_src/forward_test.py
@@ -144,6 +144,23 @@ class ForwardTest(absltest.TestCase):
 
     np.testing.assert_allclose(d.qvel.numpy()[0], 1 + mjm.opt.timestep)
 
+  def test_stepping(self):
+    path = epath.resource_path("mujoco.mjx") / "test_data/pendula.xml"
+    mjm = mujoco.MjModel.from_xml_path(path.as_posix())
+    self.assertTrue((mjm.dof_damping > 0).any())
+
+    mjd = mujoco.MjData(mjm)
+    mjd.qvel[:] = 1.0
+    mjd.qacc[:] = 1.0
+    mujoco.mj_forward(mjm, mjd)
+
+    m = mjx.put_model(mjm)
+    d = mjx.put_data(mjm, mjd)
+
+    for i in range(100):
+      mjx.step(m, d)
+    pass
+
 
 class ImplicitIntegratorTest(parameterized.TestCase):
   def _load(self, fname: str, disableFlags: int):


### PR DESCRIPTION
This is a draft and should serve as a basis for discussions. The goal is to avoid loading the same kernel over and over again. E. g.  (notice the repeating hashes):
Module mujoco.mjx._src.support 5e90a30 load on device 'cuda:0' took 70.15 ms  (cached)
Module mujoco.mjx._src.support cf9d851 load on device 'cuda:0' took 61.78 ms  (cached)
Module mujoco.mjx._src.support 1192ca8 load on device 'cuda:0' took 82.77 ms  (cached)
Module mujoco.mjx._src.support a7d0b54 load on device 'cuda:0' took 76.82 ms  (cached)
Module mujoco.mjx._src.support 00930da load on device 'cuda:0' took 79.83 ms  (cached)
Module mujoco.mjx._src.support 3495bb4 load on device 'cuda:0' took 68.93 ms  (cached)
Module mujoco.mjx._src.support beb86f2 load on device 'cuda:0' took 78.17 ms  (cached)
Module mujoco.mjx._src.support 5e90a30 load on device 'cuda:0' took 77.56 ms  (cached)
Module mujoco.mjx._src.support cf9d851 load on device 'cuda:0' took 66.32 ms  (cached)
Module mujoco.mjx._src.support 1192ca8 load on device 'cuda:0' took 75.14 ms  (cached)
Module mujoco.mjx._src.support a7d0b54 load on device 'cuda:0' took 78.98 ms  (cached)
Module mujoco.mjx._src.support 00930da load on device 'cuda:0' took 68.48 ms  (cached)
Module mujoco.mjx._src.support 3495bb4 load on device 'cuda:0' took 80.82 ms  (cached)
Module mujoco.mjx._src.support beb86f2 load on device 'cuda:0' took 69.99 ms  (cached)
Module mujoco.mjx._src.support 5e90a30 load on device 'cuda:0' took 77.21 ms  (cached)