### PR TITLE
adjust the size of the candidate pair buckets

### DIFF
--- a/mujoco/mjx/_src/io.py
+++ b/mujoco/mjx/_src/io.py
@@ -645,7 +645,7 @@ def put_data(
   d.dyn_geom_aabb = wp.zeros((nworld, mjm.ngeom, 2), dtype=wp.vec3)
 
   # internal narrowphase tmp arrays
-  ngroups = types.NUM_GEOM_TYPES
+  ngroups = types.NUM_GEOM_TYPES * types.NUM_GEOM_TYPES
   d.narrowphase_candidate_worldid = wp.empty(
     (ngroups, d.max_num_overlaps_per_world * nworld), dtype=wp.int32, ndim=2
   )

--- a/mujoco/mjx/_src/io.py
+++ b/mujoco/mjx/_src/io.py
@@ -418,7 +418,7 @@ def make_data(
   d.segment_indices = wp.array(segment_indices_list, dtype=int)
 
   # internal narrowphase tmp arrays
-  ngroups = types.NUM_GEOM_TYPES
+  ngroups = types.NUM_GEOM_TYPES * types.NUM_GEOM_TYPES
   d.narrowphase_candidate_worldid = wp.empty(
     (ngroups, d.ncon * nworld), dtype=wp.int32, ndim=2
   )


### PR DESCRIPTION
don't know how I messed that one up. Temp fix to n2 size to hold all the keys, but we should convert to a linear index because we only need the upper or lower triangular part.