### PR TITLE
Trace option for testspeed and some updated benchmarks.

### DIFF
--- a/mujoco/mjx/_src/collision_driver.py
+++ b/mujoco/mjx/_src/collision_driver.py
@@ -15,11 +15,12 @@
 
 import warp as wp
 
-from .types import Model
+from .warp_util import event_scope
 from .types import Data
-from .types import MJ_MINVAL
-from .types import vec5
 from .types import DisableBit
+from .types import MJ_MINVAL
+from .types import Model
+from .types import vec5
 from .support import where
 from .support import group_key
 
@@ -506,6 +507,7 @@ def get_contact_solver_params(m: Model, d: Data):
   # TODO(team): do we need condim sorting, deepest penetrating contact here?
 
 
+@event_scope
 def collision(m: Model, d: Data):
   """Collision detection."""
 

--- a/mujoco/mjx/_src/constraint.py
+++ b/mujoco/mjx/_src/constraint.py
@@ -15,6 +15,7 @@
 
 import warp as wp
 from . import types
+from .warp_util import event_scope
 
 
 @wp.func
@@ -208,6 +209,7 @@ def _efc_contact_pyramidal(
     )
 
 
+@event_scope
 def make_constraint(m: types.Model, d: types.Data):
   """Creates constraint jacobians and other supporting data."""
 

--- a/mujoco/mjx/_src/forward.py
+++ b/mujoco/mjx/_src/forward.py
@@ -35,6 +35,7 @@ from .types import DynType
 from .types import BiasType
 from .types import GainType
 from .support import xfrc_accumulate
+from .warp_util import event_scope
 
 
 def _advance(
@@ -159,6 +160,7 @@ def _advance(
   d.time = d.time + m.opt.timestep
 
 
+@event_scope
 def euler(m: Model, d: Data):
   """Euler integrator, semi-implicit in velocity."""
   # integrate damping implicitly
@@ -211,6 +213,7 @@ def euler(m: Model, d: Data):
     _advance(m, d, d.act_dot, d.qacc)
 
 
+@event_scope
 def implicit(m: Model, d: Data):
   """Integrates fully implicit in velocity."""
 
@@ -372,6 +375,7 @@ def implicit(m: Model, d: Data):
     _advance(m, d, d.act_dot, d.qacc)
 
 
+@event_scope
 def fwd_position(m: Model, d: Data):
   """Position-dependent computations."""
 
@@ -386,6 +390,7 @@ def fwd_position(m: Model, d: Data):
   smooth.transmission(m, d)
 
 
+@event_scope
 def fwd_velocity(m: Model, d: Data):
   """Velocity-dependent computations."""
 
@@ -464,6 +469,7 @@ def fwd_velocity(m: Model, d: Data):
   smooth.rne(m, d)
 
 
+@event_scope
 def fwd_actuation(m: Model, d: Data):
   """Actuation-dependent computations."""
   if not m.nu:
@@ -591,6 +597,7 @@ def fwd_actuation(m: Model, d: Data):
   # TODO actuator-level gravity compensation, skip if added as passive force
 
 
+@event_scope
 def fwd_acceleration(m: Model, d: Data):
   """Add up all non-constraint forces, compute qacc_smooth."""
 
@@ -619,6 +626,7 @@ def fwd_acceleration(m: Model, d: Data):
   smooth.solve_m(m, d, d.qacc_smooth, d.qfrc_smooth)
 
 
+@event_scope
 def forward(m: Model, d: Data):
   """Forward dynamics."""
 
@@ -636,6 +644,7 @@ def forward(m: Model, d: Data):
     solver.solve(m, d)
 
 
+@event_scope
 def step(m: Model, d: Data):
   """Advance simulation."""
   forward(m, d)

--- a/mujoco/mjx/_src/passive.py
+++ b/mujoco/mjx/_src/passive.py
@@ -4,8 +4,10 @@ from . import math
 from .types import Model
 from .types import Data
 from .types import JointType
+from .warp_util import event_scope
 
 
+@event_scope
 def passive(m: Model, d: Data):
   """Adds all passive forces."""
 

--- a/mujoco/mjx/_src/smooth.py
+++ b/mujoco/mjx/_src/smooth.py
@@ -22,8 +22,10 @@ from .types import array2df
 from .types import array3df
 from .types import vec10
 from .types import JointType, TrnType
+from .warp_util import event_scope
 
 
+@event_scope
 def kinematics(m: Model, d: Data):
   """Forward kinematics."""
 
@@ -107,6 +109,7 @@ def kinematics(m: Model, d: Data):
     wp.launch(_level, dim=(d.nworld, end - beg), inputs=[m, d, beg])
 
 
+@event_scope
 def com_pos(m: Model, d: Data):
   """Map inertias and motion dofs to global frame centered at subtree-CoM."""
 
@@ -218,6 +221,7 @@ def com_pos(m: Model, d: Data):
   wp.launch(cdof, dim=(d.nworld, m.njnt), inputs=[m, d])
 
 
+@event_scope
 def crb(m: Model, d: Data):
   """Composite rigid body inertia algorithm."""
 
@@ -355,11 +359,13 @@ def factor_i(m: Model, d: Data, M, L, D=None):
     _factor_i_dense(m, d, M, L)
 
 
+@event_scope
 def factor_m(m: Model, d: Data):
   """Factorizaton of inertia-like matrix M, assumed spd."""
   factor_i(m, d, d.qM, d.qLD, d.qLDiagInv)
 
 
+@event_scope
 def rne(m: Model, d: Data):
   """Computes inverse dynamics using Newton-Euler algorithm."""
 
@@ -433,6 +439,7 @@ def rne(m: Model, d: Data):
   wp.launch(qfrc_bias, dim=[d.nworld, m.nv], inputs=[m, d, cfrc])
 
 
+@event_scope
 def transmission(m: Model, d: Data):
   """Computes actuator/transmission lengths and moments."""
   if not m.nu:
@@ -502,6 +509,7 @@ def transmission(m: Model, d: Data):
   )
 
 
+@event_scope
 def com_vel(m: Model, d: Data):
   """Computes cvel, cdof_dot."""
 
@@ -655,6 +663,7 @@ def solve_LD(m: Model, d: Data, L: array3df, D: array2df, x: array2df, y: array2
     _solve_LD_dense(m, d, L, x, y)
 
 
+@event_scope
 def solve_m(m: Model, d: Data, x: array2df, y: array2df):
   """Computes backsubstitution: x = qLD * y."""
   solve_LD(m, d, d.qLD, d.qLDiagInv, x, y)

--- a/mujoco/mjx/_src/support.py
+++ b/mujoco/mjx/_src/support.py
@@ -21,6 +21,7 @@ from .types import array2df
 from .types import NUM_GEOM_TYPES
 from typing import Any
 from .types import array3df
+from .warp_util import event_scope
 
 
 def is_sparse(m: mujoco.MjModel):
@@ -29,6 +30,7 @@ def is_sparse(m: mujoco.MjModel):
   return m.opt.jacobian == mujoco.mjtJacobian.mjJAC_SPARSE
 
 
+@event_scope
 def mul_m(
   m: Model,
   d: Data,
@@ -158,6 +160,7 @@ def compute_qfrc(
   qfrc_total[worldid, dofid] = accumul
 
 
+@event_scope
 def xfrc_accumulate(m: Model, d: Data) -> array2df:
   body_treeadr_np = m.body_treeadr.numpy()
   mask = wp.zeros((m.nv, m.nbody), dtype=wp.bool)

--- a/mujoco/mjx/_src/warp_util.py
+++ b/mujoco/mjx/_src/warp_util.py
@@ -1,0 +1,79 @@
+# Copyright 2025 The Physics-Next Project Developers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+import functools
+
+import warp as wp
+
+_STACK = None
+
+
+class EventTracer:
+  def __init__(self, enabled: bool = True):
+    global _STACK
+    if enabled:
+      _STACK = {}
+
+  def __enter__(self):
+    return self
+
+  def trace(self) -> dict:
+    global _STACK
+
+    if _STACK is None:
+      return {}
+
+    ret = {}
+
+    for k, v in _STACK.items():
+      events, sub_stack = v
+      # push into next level of stack
+      saved_stack, _STACK = _STACK, sub_stack
+      sub_trace = self.trace()
+      # pop!
+      _STACK = saved_stack
+      events = tuple(wp.get_event_elapsed_time(beg, end) for beg, end in events)
+      ret[k] = (events, sub_trace)
+
+    return ret
+
+  def __exit__(self, type, value, traceback):
+    global _STACK
+    _STACK = None
+
+
+def event_scope(fn, name: str = ""):
+  name = name or getattr(fn, "__name__")
+
+  @functools.wraps(fn)
+  def wrapper(*args, **kwargs):
+    global _STACK
+    if _STACK is None:
+      return fn(*args, **kwargs)
+    # push into next level of stack
+    saved_stack, _STACK = _STACK, {}
+    beg = wp.Event(enable_timing=True)
+    end = wp.Event(enable_timing=True)
+    wp.record_event(beg)
+    res = fn(*args, **kwargs)
+    wp.record_event(end)
+    # pop back up to current level
+    sub_stack, _STACK = _STACK, saved_stack
+    # append events
+    events, _ = _STACK.get(name, ((), None))
+    _STACK[name] = (events + ((beg, end),), sub_stack)
+    return res
+
+  return wrapper


### PR DESCRIPTION
With this PR we can get some detailed perf numbers of the subcomponents of the physics step.

I've updated the benchmark to compare the results of this to MJX on `humanoid.xml`.