### PR TITLE
Tiled version of euler integration

### DIFF
--- a/mujoco/mjx/_src/forward.py
+++ b/mujoco/mjx/_src/forward.py
@@ -199,13 +199,13 @@ def euler(m: Model, d: Data):
           d.qM[worldid], shape=(tilesize, tilesize), offset=(dofid, dofid)
         )
         damping_tile = wp.tile_load(m.dof_damping, shape=(tilesize,), offset=(dofid,))
-        damping_scaled = wp.mul(damping_tile, m.opt.timestep)
+        damping_scaled = damping_tile * wp.static(m.opt.timestep)
         qm_integration_tile = wp.tile_diag_add(M_tile, damping_scaled)
 
         qfrc_smooth_tile = wp.tile_load(d.qfrc_smooth[worldid], shape=(tilesize,), offset=(dofid,))
         qfrc_constraint_tile = wp.tile_load(d.qfrc_constraint[worldid], shape=(tilesize,), offset=(dofid,))
 
-        qfrc_tile = wp.add(qfrc_smooth_tile, qfrc_constraint_tile)
+        qfrc_tile = qfrc_smooth_tile + qfrc_constraint_tile
 
         L_tile = wp.tile_cholesky(qm_integration_tile)
         qacc_tile = wp.tile_cholesky_solve(L_tile, qfrc_tile)

--- a/mujoco/mjx/_src/forward.py
+++ b/mujoco/mjx/_src/forward.py
@@ -192,13 +192,13 @@ def euler(m: Model, d: Data):
 
     def tile_eulerdamp(adr: int, size: int, tilesize: int):
       @wp.kernel
-      def eulerdamp(m: Model, d: Data, damping: wp.array(dtype=wp.float32), leveladr: int):
+      def eulerdamp(m: Model, d: Data, leveladr: int):
         worldid, nodeid = wp.tid()
         dofid = m.qLD_tile[leveladr + nodeid]
         M_tile = wp.tile_load(
           d.qM[worldid], shape=(tilesize, tilesize), offset=(dofid, dofid)
         )
-        damping_tile = wp.tile_load(damping, shape=(tilesize), offset=(dofid))
+        damping_tile = wp.tile_load(m.dof_damping, shape=(tilesize,), offset=(dofid,))
         damping_scaled = wp.mul(damping_tile, m.opt.timestep)
         qm_integration_tile = wp.tile_diag_add(M_tile, damping_scaled)
 
@@ -212,7 +212,7 @@ def euler(m: Model, d: Data):
         wp.tile_store(d.qacc_integration[worldid], qacc_tile, offset=(dofid))
 
       wp.launch_tiled(
-        eulerdamp, dim=(d.nworld, size), inputs=[m, d, m.dof_damping, adr], block_dim=32
+        eulerdamp, dim=(d.nworld, size), inputs=[m, d, adr], block_dim=32
       )
 
     qLD_tileadr, qLD_tilesize = m.qLD_tileadr.numpy(), m.qLD_tilesize.numpy()


### PR DESCRIPTION
Pretty straightforward, similar to implicit integrator. There's more to be gained by fusing in advance as well but I need to figure out interface considerations/composability first.

Timings are pretty similar for a single humanoid, but for 5 humanoids there is a good speedup:

before:
```
Summary for 8192 parallel rollouts

 Total JIT time: 1.26 s
 Total simulation time: 12.44 s
 Total steps per second: 658,355
 Total realtime factor: 3,291.78 x
 Total time per step: 1518.94 ns
```

after:
```
Summary for 8192 parallel rollouts

 Total JIT time: 1.28 s
 Total simulation time: 11.32 s
 Total steps per second: 723,993
 Total realtime factor: 3,619.96 x
 Total time per step: 1381.23 ns
```

