### PR TITLE
Temporarily pin to MuJoCo==3.2.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ requires-python = ">=3.9"
 dependencies = [
     "absl-py",
     "etils[epath]",
-    "mujoco>=3.2.7",
+    "mujoco==3.2.7",
     "pytest",
     "trimesh",
     "warp-lang",


### PR DESCRIPTION
MuJoCo 3.3.0 changed its qM layout - we'll fix ours to match after GTC.