### PR TITLE
Remove inline allocs from smooth and xfrc_accumulate.

### DIFF
--- a/mujoco/mjx/_src/io.py
+++ b/mujoco/mjx/_src/io.py
@@ -394,6 +394,9 @@ def make_data(
   d.efc_margin = wp.zeros((njmax,), dtype=wp.float32)
   d.efc_worldid = wp.zeros((njmax,), dtype=wp.int32)
 
+  d.rne_cacc = wp.zeros(shape=(d.nworld, mjm.nbody), dtype=wp.spatial_vector)
+  d.rne_cfrc = wp.zeros(shape=(d.nworld, mjm.nbody), dtype=wp.spatial_vector)
+
   d.xfrc_applied = wp.zeros((nworld, mjm.nbody), dtype=wp.spatial_vector)
 
   # internal tmp arrays
@@ -621,6 +624,9 @@ def put_data(
   d.contact.geom = wp.array(con_geom_fill, dtype=wp.vec2i, ndim=1)
   d.contact.efc_address = wp.array(con_efc_address, dtype=wp.int32, ndim=1)
   d.contact.worldid = wp.array(con_worldid, dtype=wp.int32, ndim=1)
+
+  d.rne_cacc = wp.zeros(shape=(d.nworld, mjm.nbody), dtype=wp.spatial_vector)
+  d.rne_cfrc = wp.zeros(shape=(d.nworld, mjm.nbody), dtype=wp.spatial_vector)
 
   d.xfrc_applied = wp.array(tile(mjd.xfrc_applied), dtype=wp.spatial_vector, ndim=2)
 

--- a/mujoco/mjx/_src/io.py
+++ b/mujoco/mjx/_src/io.py
@@ -666,8 +666,8 @@ def put_data(
 
   d.rne_cacc = wp.zeros(shape=(d.nworld, mjm.nbody), dtype=wp.spatial_vector)
   d.rne_cfrc = wp.zeros(shape=(d.nworld, mjm.nbody), dtype=wp.spatial_vector)
-  d.efc = _constraint(mjm.nv, d.nworld, d.njmax)
 
+  d.efc = _constraint(mjm.nv, d.nworld, d.njmax)
   d.efc.J = wp.array(efc_J_fill, dtype=wp.float32, ndim=2)
   d.efc.D = wp.array(efc_D_fill, dtype=wp.float32, ndim=1)
   d.efc.pos = wp.array(efc_pos_fill, dtype=wp.float32, ndim=1)

--- a/mujoco/mjx/_src/support.py
+++ b/mujoco/mjx/_src/support.py
@@ -113,40 +113,25 @@ def mul_m(
     )
 
 
-@wp.kernel
-def process_level(
-  body_tree: wp.array(ndim=1, dtype=int),
-  body_parentid: wp.array(ndim=1, dtype=int),
-  dof_bodyid: wp.array(ndim=1, dtype=int),
-  mask: wp.array2d(dtype=wp.bool),
-  beg: int,
-):
-  dofid, tid_y = wp.tid()
-  j = beg + tid_y
-  el = body_tree[j]
-  parent_id = body_parentid[el]
-  parent_val = mask[dofid, parent_id]
-  mask[dofid, el] = parent_val or (dof_bodyid[dofid] == el)
+@event_scope
+def xfrc_accumulate(m: Model, d: Data, qfrc: array2df):
+  @wp.kernel
+  def _accumulate(m: Model, d: Data, qfrc: array2df):
+    worldid, dofid = wp.tid()
+    cdof = d.cdof[worldid, dofid]
+    rotational_cdof = wp.vec3(cdof[0], cdof[1], cdof[2])
+    jac = wp.spatial_vector(cdof[3], cdof[4], cdof[5], cdof[0], cdof[1], cdof[2])
 
+    dof_bodyid = m.dof_bodyid[dofid]
+    accumul = float(0.0)
 
-@wp.kernel
-def compute_qfrc(
-  d: Data,
-  m: Model,
-  mask: wp.array2d(dtype=wp.bool),
-  qfrc_total: array2df,
-):
-  worldid, dofid = wp.tid()
-  accumul = float(0.0)
-  cdof_vec = d.cdof[worldid, dofid]
-  rotational_cdof = wp.vec3(cdof_vec[0], cdof_vec[1], cdof_vec[2])
-
-  jac = wp.spatial_vector(
-    cdof_vec[3], cdof_vec[4], cdof_vec[5], cdof_vec[0], cdof_vec[1], cdof_vec[2]
-  )
-
-  for bodyid in range(m.nbody):
-    if mask[dofid, bodyid]:
+    for bodyid in range(dof_bodyid, m.nbody):
+      # any body that is in the subtree of dof_bodyid is part of the jacobian
+      parentid = bodyid
+      while parentid != 0 and parentid != dof_bodyid:
+        parentid = m.body_parentid[parentid]
+      if parentid == 0:
+        continue  # body is not part of the subtree
       offset = d.xipos[worldid, bodyid] - d.subtree_com[worldid, m.body_rootid[bodyid]]
       cross_term = wp.cross(rotational_cdof, offset)
       accumul += wp.dot(jac, d.xfrc_applied[worldid, bodyid]) + wp.dot(
@@ -158,30 +143,9 @@ def compute_qfrc(
         ),
       )
 
-  qfrc_total[worldid, dofid] = accumul
+    qfrc[worldid, dofid] += accumul
 
-
-@event_scope
-def xfrc_accumulate(m: Model, d: Data) -> array2df:
-  body_treeadr_np = m.body_treeadr.numpy()
-  mask = wp.zeros((m.nv, m.nbody), dtype=wp.bool)
-
-  for i in range(len(body_treeadr_np)):
-    beg = body_treeadr_np[i]
-    end = m.nbody if i == len(body_treeadr_np) - 1 else body_treeadr_np[i + 1]
-
-    if end > beg:
-      wp.launch(
-        kernel=process_level,
-        dim=[m.nv, (end - beg)],
-        inputs=[m.body_tree, m.body_parentid, m.dof_bodyid, mask, beg],
-      )
-
-  qfrc_total = wp.zeros((d.nworld, m.nv), dtype=float)
-
-  wp.launch(kernel=compute_qfrc, dim=(d.nworld, m.nv), inputs=[d, m, mask, qfrc_total])
-
-  return qfrc_total
+  wp.launch(kernel=_accumulate, dim=(d.nworld, m.nv), inputs=[m, d, qfrc])
 
 
 @wp.func

--- a/mujoco/mjx/_src/support_test.py
+++ b/mujoco/mjx/_src/support_test.py
@@ -60,21 +60,16 @@ class SupportTest(parameterized.TestCase):
     mjm, mjd, m, d = test_util.fixture("pendula.xml")
     xfrc = np.random.randn(*d.xfrc_applied.numpy().shape)
     d.xfrc_applied = wp.from_numpy(xfrc, dtype=wp.spatial_vector)
-    qfrc = xfrc_accumulate(m, d)
+    qfrc = wp.zeros((1, mjm.nv), dtype=wp.float32)
+    xfrc_accumulate(m, d, qfrc)
 
     qfrc_expected = np.zeros(m.nv)
     xfrc = xfrc[0]
-    mjd.xfrc_applied[:] = xfrc
     for i in range(1, m.nbody):
       mujoco.mj_applyFT(
-        mjm,
-        mjd,
-        mjd.xfrc_applied[i, :3],
-        mjd.xfrc_applied[i, 3:],
-        mjd.xipos[i],
-        i,
-        qfrc_expected,
+        mjm, mjd, xfrc[i, :3], xfrc[i, 3:], mjd.xipos[i], i, qfrc_expected
       )
+    np.set_printoptions(suppress=True, linewidth=1000, precision=5)
     np.testing.assert_almost_equal(qfrc.numpy()[0], qfrc_expected, 6)
 
   def test_make_put_data(self):

--- a/mujoco/mjx/_src/support_test.py
+++ b/mujoco/mjx/_src/support_test.py
@@ -69,7 +69,6 @@ class SupportTest(parameterized.TestCase):
       mujoco.mj_applyFT(
         mjm, mjd, xfrc[i, :3], xfrc[i, 3:], mjd.xipos[i], i, qfrc_expected
       )
-    np.set_printoptions(suppress=True, linewidth=1000, precision=5)
     np.testing.assert_almost_equal(qfrc.numpy()[0], qfrc_expected, 6)
 
   def test_make_put_data(self):

--- a/mujoco/mjx/_src/types.py
+++ b/mujoco/mjx/_src/types.py
@@ -419,6 +419,10 @@ class Data:
   xfrc_applied: wp.array(dtype=wp.spatial_vector, ndim=2)
   contact: Contact
 
+  # arrays used for smooth.rne
+  rne_cacc: wp.array(dtype=wp.spatial_vector, ndim=2)
+  rne_cfrc: wp.array(dtype=wp.spatial_vector, ndim=2)
+
   # temp arrays
   qfrc_integration: wp.array(dtype=wp.float32, ndim=2)
   qacc_integration: wp.array(dtype=wp.float32, ndim=2)


### PR DESCRIPTION
In order to work with JAX graph capture, we must avoid any allocs inside of simulation kernels.

I had to modify `xfrc_accumulate` a bit to remove the mask allocation, but seems to have had no (or perhaps slightly positive) impact on perf.

Result of `mjx-testspeed --function=fwd_acceleration --is_sparse=False --mjcf=humanoid/humanoid.xml --batch_size=8192 --solver=newton --event_trace=True`

This PR:

```
Summary for 8192 parallel rollouts

 Total JIT time: 0.02 s
 Total simulation time: 0.07 s
 Total steps per second: 118,669,204
 Total realtime factor: 593,346.02 x
 Total time per step: 8.43 ns

Event trace:

fwd_acceleration: 6.98
  xfrc_accumulate: 2.63
  solve_m: 3.49
```

Main:

```
Summary for 8192 parallel rollouts

 Total JIT time: 0.56 s
 Total simulation time: 0.07 s
 Total steps per second: 110,029,050
 Total realtime factor: 550,145.25 x
 Total time per step: 9.09 ns

Event trace:

fwd_acceleration: 7.61
  xfrc_accumulate: 3.23
  solve_m: 3.51
```