### PR TITLE
restructure solver memory

### DIFF
--- a/mujoco/mjx/_src/constraint.py
+++ b/mujoco/mjx/_src/constraint.py
@@ -66,10 +66,10 @@ def _update_efc_row(
   imp = wp.select(imp_x > 1.0, imp, dmax)
 
   # Update constraints
-  d.efc_D[efcid] = 1.0 / wp.max(invweight * (1.0 - imp) / imp, types.MJ_MINVAL)
-  d.efc_aref[efcid] = -k * imp * pos_aref - b * Jqvel
-  d.efc_pos[efcid] = pos_aref + margin
-  d.efc_margin[efcid] = margin
+  d.efc.D[efcid] = 1.0 / wp.max(invweight * (1.0 - imp) / imp, types.MJ_MINVAL)
+  d.efc.aref[efcid] = -k * imp * pos_aref - b * Jqvel
+  d.efc.pos[efcid] = pos_aref + margin
+  d.efc.margin[efcid] = margin
 
 
 @wp.func
@@ -116,12 +116,12 @@ def _efc_limit_slide_hinge(
 
   if active:
     efcid = wp.atomic_add(d.nefc_total, 0, 1)
-    d.efc_worldid[efcid] = worldid
+    d.efc.worldid[efcid] = worldid
 
     dofadr = m.jnt_dofadr[jntid]
 
     J = float(dist_min < dist_max) * 2.0 - 1.0
-    d.efc_J[efcid, dofadr] = J
+    d.efc.J[efcid, dofadr] = J
     Jqvel = J * d.qvel[worldid, dofadr]
 
     _update_efc_row(
@@ -160,7 +160,7 @@ def _efc_contact_pyramidal(
   if active:
     efcid = wp.atomic_add(d.nefc_total, 0, 1)
     worldid = d.contact.worldid[conid]
-    d.efc_worldid[efcid] = worldid
+    d.efc.worldid[efcid] = worldid
 
     body1 = m.geom_bodyid[d.contact.geom[conid][0]]
     body2 = m.geom_bodyid[d.contact.geom[conid][1]]
@@ -190,7 +190,7 @@ def _efc_contact_pyramidal(
       else:
         J = diff_0 - diff_i * d.contact.friction[conid][dimid2 - 1]
 
-      d.efc_J[efcid, i] = J
+      d.efc.J[efcid, i] = J
       Jqvel += J * d.qvel[worldid, i]
 
     _update_efc_row(
@@ -215,7 +215,7 @@ def make_constraint(m: types.Model, d: types.Data):
 
   if not (m.opt.disableflags & types.DisableBit.CONSTRAINT.value):
     d.nefc_total.zero_()
-    d.efc_J.zero_()
+    d.efc.J.zero_()
 
     refsafe = not m.opt.disableflags & types.DisableBit.REFSAFE.value
 

--- a/mujoco/mjx/_src/constraint_test.py
+++ b/mujoco/mjx/_src/constraint_test.py
@@ -47,11 +47,11 @@ class ConstraintTest(parameterized.TestCase):
       d = mjx.put_data(mjm, mjd)
       mjx.make_constraint(m, d)
 
-      _assert_eq(d.efc_J.numpy()[: mjd.nefc, :].reshape(-1), mjd.efc_J, "efc_J")
-      _assert_eq(d.efc_D.numpy()[: mjd.nefc], mjd.efc_D, "efc_D")
-      _assert_eq(d.efc_aref.numpy()[: mjd.nefc], mjd.efc_aref, "efc_aref")
-      _assert_eq(d.efc_pos.numpy()[: mjd.nefc], mjd.efc_pos, "efc_pos")
-      _assert_eq(d.efc_margin.numpy()[: mjd.nefc], mjd.efc_margin, "efc_margin")
+      _assert_eq(d.efc.J.numpy()[: mjd.nefc, :].reshape(-1), mjd.efc_J, "efc_J")
+      _assert_eq(d.efc.D.numpy()[: mjd.nefc], mjd.efc_D, "efc_D")
+      _assert_eq(d.efc.aref.numpy()[: mjd.nefc], mjd.efc_aref, "efc_aref")
+      _assert_eq(d.efc.pos.numpy()[: mjd.nefc], mjd.efc_pos, "efc_pos")
+      _assert_eq(d.efc.margin.numpy()[: mjd.nefc], mjd.efc_margin, "efc_margin")
 
 
 if __name__ == "__main__":

--- a/mujoco/mjx/_src/solver.py
+++ b/mujoco/mjx/_src/solver.py
@@ -7,146 +7,86 @@ from .warp_util import event_scope
 from .warp_util import kernel
 
 
-@wp.struct
-class Context:
-  Jaref: wp.array(dtype=wp.float32, ndim=1)
-  Ma: wp.array(dtype=wp.float32, ndim=2)
-  grad: wp.array(dtype=wp.float32, ndim=2)
-  grad_dot: wp.array(dtype=wp.float32, ndim=1)
-  Mgrad: wp.array(dtype=wp.float32, ndim=2)
-  search: wp.array(dtype=wp.float32, ndim=2)
-  search_dot: wp.array(dtype=wp.float32, ndim=1)
-  gauss: wp.array(dtype=wp.float32, ndim=1)
-  cost: wp.array(dtype=wp.float32, ndim=1)
-  prev_cost: wp.array(dtype=wp.float32, ndim=1)
-  solver_niter: wp.array(dtype=wp.int32, ndim=1)
-  active: wp.array(dtype=wp.int32, ndim=1)
-  gtol: wp.array(dtype=wp.float32, ndim=1)
-  mv: wp.array(dtype=wp.float32, ndim=2)
-  jv: wp.array(dtype=wp.float32, ndim=1)
-  quad: wp.array(dtype=wp.vec3f, ndim=1)
-  quad_gauss: wp.array(dtype=wp.vec3f, ndim=1)
-  h: wp.array(dtype=wp.float32, ndim=3)
-  alpha: wp.array(dtype=wp.float32, ndim=1)
-  prev_grad: wp.array(dtype=wp.float32, ndim=2)
-  prev_Mgrad: wp.array(dtype=wp.float32, ndim=2)
-  beta: wp.array(dtype=wp.float32, ndim=1)
-  beta_num: wp.array(dtype=wp.float32, ndim=1)
-  beta_den: wp.array(dtype=wp.float32, ndim=1)
-  done: wp.array(dtype=wp.int32, ndim=1)
-
-
-def _context(m: types.Model, d: types.Data) -> Context:
-  ctx = Context()
-  ctx.Jaref = wp.empty(shape=(d.njmax,), dtype=wp.float32)
-  ctx.Ma = wp.empty(shape=(d.nworld, m.nv), dtype=wp.float32)
-  ctx.grad = wp.empty(shape=(d.nworld, m.nv), dtype=wp.float32)
-  ctx.grad_dot = wp.empty(shape=(d.nworld,), dtype=wp.float32)
-  ctx.Mgrad = wp.empty(shape=(d.nworld, m.nv), dtype=wp.float32)
-  ctx.search = wp.empty(shape=(d.nworld, m.nv), dtype=wp.float32)
-  ctx.search_dot = wp.empty(shape=(d.nworld,), dtype=wp.float32)
-  ctx.gauss = wp.empty(shape=(d.nworld,), dtype=wp.float32)
-  ctx.cost = wp.empty(shape=(d.nworld,), dtype=wp.float32)
-  ctx.prev_cost = wp.empty(shape=(d.nworld,), dtype=wp.float32)
-  ctx.solver_niter = wp.empty(shape=(d.nworld,), dtype=wp.int32)
-  ctx.active = wp.empty(shape=(d.njmax,), dtype=wp.int32)
-  ctx.gtol = wp.empty(shape=(d.nworld,), dtype=wp.float32)
-  ctx.mv = wp.empty(shape=(d.nworld, m.nv), dtype=wp.float32)
-  ctx.jv = wp.empty(shape=(d.njmax,), dtype=wp.float32)
-  ctx.quad = wp.empty(shape=(d.njmax,), dtype=wp.vec3f)
-  ctx.quad_gauss = wp.empty(shape=(d.nworld,), dtype=wp.vec3f)
-  ctx.h = wp.empty(shape=(d.nworld, m.nv, m.nv), dtype=wp.float32)
-  ctx.alpha = wp.empty(shape=(d.nworld,), dtype=wp.float32)
-  ctx.prev_grad = wp.empty(shape=(d.nworld, m.nv), dtype=wp.float32)
-  ctx.prev_Mgrad = wp.empty(shape=(d.nworld, m.nv), dtype=wp.float32)
-  ctx.beta = wp.empty(shape=(d.nworld,), dtype=wp.float32)
-  ctx.beta_num = wp.empty(shape=(d.nworld,), dtype=wp.float32)
-  ctx.beta_den = wp.empty(shape=(d.nworld,), dtype=wp.float32)
-  ctx.done = wp.empty(shape=(d.nworld,), dtype=wp.int32)
-
-  return ctx
-
-
-def _create_context(ctx: Context, m: types.Model, d: types.Data, grad: bool = True):
+def _create_context(m: types.Model, d: types.Data, grad: bool = True):
   @kernel
-  def _init_context(ctx: Context):
+  def _init_context(d: types.Data):
     worldid = wp.tid()
-    ctx.cost[worldid] = wp.inf
-    ctx.solver_niter[worldid] = 0
-    ctx.done[worldid] = 0
+    d.efc.cost[worldid] = wp.inf
+    d.efc.solver_niter[worldid] = 0
+    d.efc.done[worldid] = 0
     if grad:
-      ctx.search_dot[worldid] = 0.0
+      d.efc.search_dot[worldid] = 0.0
 
   @kernel
-  def _jaref(ctx: Context, m: types.Model, d: types.Data):
+  def _jaref(m: types.Model, d: types.Data):
     efcid, dofid = wp.tid()
 
     if efcid >= d.nefc_total[0]:
       return
 
-    worldid = d.efc_worldid[efcid]
+    worldid = d.efc.worldid[efcid]
     wp.atomic_add(
-      ctx.Jaref,
+      d.efc.Jaref,
       efcid,
-      d.efc_J[efcid, dofid] * d.qacc[worldid, dofid] - d.efc_aref[efcid] / float(m.nv),
+      d.efc.J[efcid, dofid] * d.qacc[worldid, dofid] - d.efc.aref[efcid] / float(m.nv),
     )
 
   @kernel
-  def _search(ctx: Context):
+  def _search(d: types.Data):
     worldid, dofid = wp.tid()
-    search = -1.0 * ctx.Mgrad[worldid, dofid]
-    ctx.search[worldid, dofid] = search
-    wp.atomic_add(ctx.search_dot, worldid, search * search)
+    search = -1.0 * d.efc.Mgrad[worldid, dofid]
+    d.efc.search[worldid, dofid] = search
+    wp.atomic_add(d.efc.search_dot, worldid, search * search)
 
-  wp.launch(_init_context, dim=(d.nworld), inputs=[ctx])
+  wp.launch(_init_context, dim=(d.nworld), inputs=[d])
 
   # jaref = d.efc_J @ d.qacc - d.efc_aref
-  ctx.Jaref.zero_()
+  d.efc.Jaref.zero_()
 
-  wp.launch(_jaref, dim=(d.njmax, m.nv), inputs=[ctx, m, d])
+  wp.launch(_jaref, dim=(d.njmax, m.nv), inputs=[m, d])
 
   # Ma = qM @ qacc
-  support.mul_m(m, d, ctx.Ma, d.qacc)
+  support.mul_m(m, d, d.efc.Ma, d.qacc)
 
-  _update_constraint(m, d, ctx)
+  _update_constraint(m, d)
   if grad:
-    _update_gradient(m, d, ctx)
+    _update_gradient(m, d)
 
     # search = -Mgrad
-    wp.launch(_search, dim=(d.nworld, m.nv), inputs=[ctx])
+    wp.launch(_search, dim=(d.nworld, m.nv), inputs=[d])
 
 
-def _update_constraint(m: types.Model, d: types.Data, ctx: Context):
+def _update_constraint(m: types.Model, d: types.Data):
   @kernel
-  def _init_cost(ctx: Context):
+  def _init_cost(d: types.Data):
     worldid = wp.tid()
-    ctx.prev_cost[worldid] = ctx.cost[worldid]
-    ctx.cost[worldid] = 0.0
-    ctx.gauss[worldid] = 0.0
+    d.efc.prev_cost[worldid] = d.efc.cost[worldid]
+    d.efc.cost[worldid] = 0.0
+    d.efc.gauss[worldid] = 0.0
 
   @kernel
-  def _efc_kernel(ctx: Context, d: types.Data):
+  def _efc_kernel(d: types.Data):
     efcid = wp.tid()
 
     if efcid >= d.nefc_total[0]:
       return
 
-    worldid = d.efc_worldid[efcid]
-    Jaref = ctx.Jaref[efcid]
-    efc_D = d.efc_D[efcid]
+    worldid = d.efc.worldid[efcid]
+    Jaref = d.efc.Jaref[efcid]
+    efc_D = d.efc.D[efcid]
 
     # TODO(team): active and conditionally active constraints
     active = int(Jaref < 0.0)
-    ctx.active[efcid] = active
+    d.efc.active[efcid] = active
 
     if active:
       # efc_force = -efc_D * Jaref * active
-      d.efc_force[efcid] = -1.0 * efc_D * Jaref
+      d.efc.force[efcid] = -1.0 * efc_D * Jaref
 
       # cost = 0.5 * sum(efc_D * Jaref * Jaref * active))
-      wp.atomic_add(ctx.cost, worldid, 0.5 * efc_D * Jaref * Jaref)
+      wp.atomic_add(d.efc.cost, worldid, 0.5 * efc_D * Jaref * Jaref)
     else:
-      d.efc_force[efcid] = 0.0
+      d.efc.force[efcid] = 0.0
 
   @kernel
   def _qfrc_constraint(d: types.Data):
@@ -155,27 +95,27 @@ def _update_constraint(m: types.Model, d: types.Data, ctx: Context):
     if efcid >= d.nefc_total[0]:
       return
 
-    worldid = d.efc_worldid[efcid]
+    worldid = d.efc.worldid[efcid]
     wp.atomic_add(
       d.qfrc_constraint[worldid],
       dofid,
-      d.efc_J[efcid, dofid] * d.efc_force[efcid],
+      d.efc.J[efcid, dofid] * d.efc.force[efcid],
     )
 
   @kernel
-  def _gauss(ctx: Context, d: types.Data):
+  def _gauss(d: types.Data):
     worldid, dofid = wp.tid()
     gauss_cost = (
       0.5
-      * (ctx.Ma[worldid, dofid] - d.qfrc_smooth[worldid, dofid])
+      * (d.efc.Ma[worldid, dofid] - d.qfrc_smooth[worldid, dofid])
       * (d.qacc[worldid, dofid] - d.qacc_smooth[worldid, dofid])
     )
-    wp.atomic_add(ctx.gauss, worldid, gauss_cost)
-    wp.atomic_add(ctx.cost, worldid, gauss_cost)
+    wp.atomic_add(d.efc.gauss, worldid, gauss_cost)
+    wp.atomic_add(d.efc.cost, worldid, gauss_cost)
 
-  wp.launch(_init_cost, dim=(d.nworld), inputs=[ctx])
+  wp.launch(_init_cost, dim=(d.nworld), inputs=[d])
 
-  wp.launch(_efc_kernel, dim=(d.njmax,), inputs=[ctx, d])
+  wp.launch(_efc_kernel, dim=(d.njmax,), inputs=[d])
 
   # qfrc_constraint = efc_J.T @ efc_force
   d.qfrc_constraint.zero_()
@@ -184,50 +124,50 @@ def _update_constraint(m: types.Model, d: types.Data, ctx: Context):
 
   # gauss = 0.5 * (Ma - qfrc_smooth).T @ (qacc - qacc_smooth)
 
-  wp.launch(_gauss, dim=(d.nworld, m.nv), inputs=[ctx, d])
+  wp.launch(_gauss, dim=(d.nworld, m.nv), inputs=[d])
 
 
-def _update_gradient(m: types.Model, d: types.Data, ctx: Context):
+def _update_gradient(m: types.Model, d: types.Data):
   TILE = m.nv
 
   @kernel
-  def _grad(ctx: Context, d: types.Data):
+  def _grad(d: types.Data):
     worldid, dofid = wp.tid()
     grad = (
-      ctx.Ma[worldid, dofid]
+      d.efc.Ma[worldid, dofid]
       - d.qfrc_smooth[worldid, dofid]
       - d.qfrc_constraint[worldid, dofid]
     )
-    ctx.grad[worldid, dofid] = grad
-    wp.atomic_add(ctx.grad_dot, worldid, grad * grad)
+    d.efc.grad[worldid, dofid] = grad
+    wp.atomic_add(d.efc.grad_dot, worldid, grad * grad)
 
   if m.opt.is_sparse:
 
     @kernel
-    def _zero_h_lower(m: types.Model, ctx: Context):
+    def _zero_h_lower(m: types.Model, d: types.Data):
       worldid, elementid = wp.tid()
       rowid = m.dof_tri_row[elementid]
       colid = m.dof_tri_col[elementid]
-      ctx.h[worldid, rowid, colid] = 0.0
+      d.efc.h[worldid, rowid, colid] = 0.0
 
     @kernel
-    def _set_h_qM_lower_sparse(m: types.Model, d: types.Data, ctx: Context):
+    def _set_h_qM_lower_sparse(m: types.Model, d: types.Data):
       worldid, elementid = wp.tid()
       i = m.qM_fullm_i[elementid]
       j = m.qM_fullm_j[elementid]
-      ctx.h[worldid, i, j] = d.qM[worldid, 0, elementid]
+      d.efc.h[worldid, i, j] = d.qM[worldid, 0, elementid]
 
   else:
 
     @kernel
-    def _copy_lower_triangle(m: types.Model, d: types.Data, ctx: Context):
+    def _copy_lower_triangle(m: types.Model, d: types.Data):
       worldid, elementid = wp.tid()
       rowid = m.dof_tri_row[elementid]
       colid = m.dof_tri_col[elementid]
-      ctx.h[worldid, rowid, colid] = d.qM[worldid, rowid, colid]
+      d.efc.h[worldid, rowid, colid] = d.qM[worldid, rowid, colid]
 
   @kernel
-  def _JTDAJ(ctx: Context, m: types.Model, d: types.Data):
+  def _JTDAJ(m: types.Model, d: types.Data):
     efcid, elementid = wp.tid()
 
     if efcid >= d.nefc_total[0]:
@@ -236,30 +176,30 @@ def _update_gradient(m: types.Model, d: types.Data, ctx: Context):
     dofi = m.dof_tri_row[elementid]
     dofj = m.dof_tri_col[elementid]
 
-    efc_D = d.efc_D[efcid]
-    active = ctx.active[efcid]
+    efc_D = d.efc.D[efcid]
+    active = d.efc.active[efcid]
     if efc_D == 0.0 or active == 0:
       return
 
-    worldid = d.efc_worldid[efcid]
+    worldid = d.efc.worldid[efcid]
     # TODO(team): sparse efc_J
     wp.atomic_add(
-      ctx.h[worldid, dofi],
+      d.efc.h[worldid, dofi],
       dofj,
-      d.efc_J[efcid, dofi] * d.efc_J[efcid, dofj] * efc_D,
+      d.efc.J[efcid, dofi] * d.efc.J[efcid, dofj] * efc_D,
     )
 
   @kernel(module="unique")
-  def _cholesky(ctx: Context):
+  def _cholesky(d: types.Data):
     worldid = wp.tid()
-    mat_tile = wp.tile_load(ctx.h[worldid], shape=(TILE, TILE))
+    mat_tile = wp.tile_load(d.efc.h[worldid], shape=(TILE, TILE))
     fact_tile = wp.tile_cholesky(mat_tile)
-    input_tile = wp.tile_load(ctx.grad[worldid], shape=TILE)
+    input_tile = wp.tile_load(d.efc.grad[worldid], shape=TILE)
     output_tile = wp.tile_cholesky_solve(fact_tile, input_tile)
-    wp.tile_store(ctx.Mgrad[worldid], output_tile)
+    wp.tile_store(d.efc.Mgrad[worldid], output_tile)
 
   @kernel
-  def _JTDAJ(ctx: Context, m: types.Model, d: types.Data):
+  def _JTDAJ(m: types.Model, d: types.Data):
     efcid, elementid = wp.tid()
 
     if efcid >= d.nefc_total[0]:
@@ -268,40 +208,38 @@ def _update_gradient(m: types.Model, d: types.Data, ctx: Context):
     dofi = m.dof_tri_row[elementid]
     dofj = m.dof_tri_col[elementid]
 
-    efc_D = d.efc_D[efcid]
-    active = ctx.active[efcid]
+    efc_D = d.efc.D[efcid]
+    active = d.efc.active[efcid]
     if efc_D == 0.0 or active == 0:
       return
 
-    worldid = d.efc_worldid[efcid]
+    worldid = d.efc.worldid[efcid]
     # TODO(team): sparse efc_J
     # h[worldid, dofi, dofj] += J[efcid, dofi] * J[efcid, dofj] * D[efcid]
-    res = d.efc_J[efcid, dofi] * d.efc_J[efcid, dofj] * efc_D
-    wp.atomic_add(ctx.h[worldid, dofi], dofj, res)
+    res = d.efc.J[efcid, dofi] * d.efc.J[efcid, dofj] * efc_D
+    wp.atomic_add(d.efc.h[worldid, dofi], dofj, res)
 
   # grad = Ma - qfrc_smooth - qfrc_constraint
-  ctx.grad_dot.zero_()
+  d.efc.grad_dot.zero_()
 
-  wp.launch(_grad, dim=(d.nworld, m.nv), inputs=[ctx, d])
+  wp.launch(_grad, dim=(d.nworld, m.nv), inputs=[d])
 
   if m.opt.solver == mujoco.mjtSolver.mjSOL_CG:
-    smooth.solve_m(m, d, ctx.grad, ctx.Mgrad)
+    smooth.solve_m(m, d, d.efc.grad, d.efc.Mgrad)
   elif m.opt.solver == mujoco.mjtSolver.mjSOL_NEWTON:
     # h = qM + (efc_J.T * efc_D * active) @ efc_J
     if m.opt.is_sparse:
-      wp.launch(_zero_h_lower, dim=(d.nworld, m.dof_tri_row.size), inputs=[m, ctx])
+      wp.launch(_zero_h_lower, dim=(d.nworld, m.dof_tri_row.size), inputs=[m, d])
 
       wp.launch(
-        _set_h_qM_lower_sparse, dim=(d.nworld, m.qM_fullm_i.size), inputs=[m, d, ctx]
+        _set_h_qM_lower_sparse, dim=(d.nworld, m.qM_fullm_i.size), inputs=[m, d]
       )
     else:
-      wp.launch(
-        _copy_lower_triangle, dim=(d.nworld, m.dof_tri_row.size), inputs=[m, d, ctx]
-      )
+      wp.launch(_copy_lower_triangle, dim=(d.nworld, m.dof_tri_row.size), inputs=[m, d])
 
-    wp.launch(_JTDAJ, dim=(d.njmax, m.dof_tri_row.size), inputs=[ctx, m, d])
+    wp.launch(_JTDAJ, dim=(d.njmax, m.dof_tri_row.size), inputs=[m, d])
 
-    wp.launch_tiled(_cholesky, dim=(d.nworld,), inputs=[ctx], block_dim=32)
+    wp.launch_tiled(_cholesky, dim=(d.nworld,), inputs=[d], block_dim=32)
 
 
 @wp.func
@@ -329,71 +267,71 @@ def _safe_div(x: wp.float32, y: wp.float32) -> wp.float32:
 
 
 @event_scope
-def _linesearch_iterative(m: types.Model, d: types.Data, ctx: Context):
+def _linesearch_iterative(m: types.Model, d: types.Data):
   @kernel
-  def _gtol(m: types.Model, ctx: Context):
+  def _gtol(m: types.Model, d: types.Data):
     # TODO(team): static m?
     worldid = wp.tid()
-    snorm = wp.math.sqrt(ctx.search_dot[worldid])
+    snorm = wp.math.sqrt(d.efc.search_dot[worldid])
     scale = m.stat.meaninertia * wp.float(wp.max(1, m.nv))
-    ctx.gtol[worldid] = m.opt.tolerance * m.opt.ls_tolerance * snorm * scale
+    d.efc.gtol[worldid] = m.opt.tolerance * m.opt.ls_tolerance * snorm * scale
 
   @kernel
-  def _jv(d: types.Data, ctx: Context):
+  def _jv(d: types.Data):
     efcid, dofid = wp.tid()
 
     if efcid >= d.nefc_total[0]:
       return
 
-    j = d.efc_J[efcid, dofid]
-    search = ctx.search[d.efc_worldid[efcid], dofid]
-    wp.atomic_add(ctx.jv, efcid, j * search)
+    j = d.efc.J[efcid, dofid]
+    search = d.efc.search[d.efc.worldid[efcid], dofid]
+    wp.atomic_add(d.efc.jv, efcid, j * search)
 
   @kernel
-  def _init_quad_gauss(m: types.Model, d: types.Data, ctx: Context):
+  def _init_quad_gauss(m: types.Model, d: types.Data):
     worldid, dofid = wp.tid()
-    search = ctx.search[worldid, dofid]
+    search = d.efc.search[worldid, dofid]
     quad_gauss = wp.vec3()
-    quad_gauss[0] = ctx.gauss[worldid] / float(m.nv)
-    quad_gauss[1] = search * (ctx.Ma[worldid, dofid] - d.qfrc_smooth[worldid, dofid])
-    quad_gauss[2] = 0.5 * search * ctx.mv[worldid, dofid]
-    wp.atomic_add(ctx.quad_gauss, worldid, quad_gauss)
+    quad_gauss[0] = d.efc.gauss[worldid] / float(m.nv)
+    quad_gauss[1] = search * (d.efc.Ma[worldid, dofid] - d.qfrc_smooth[worldid, dofid])
+    quad_gauss[2] = 0.5 * search * d.efc.mv[worldid, dofid]
+    wp.atomic_add(d.efc.quad_gauss, worldid, quad_gauss)
 
   @kernel
-  def _init_quad(d: types.Data, ctx: Context):
+  def _init_quad(d: types.Data):
     efcid = wp.tid()
 
     if efcid >= d.nefc_total[0]:
       return
 
-    Jaref = ctx.Jaref[efcid]
-    jv = ctx.jv[efcid]
-    efc_D = d.efc_D[efcid]
+    Jaref = d.efc.Jaref[efcid]
+    jv = d.efc.jv[efcid]
+    efc_D = d.efc.D[efcid]
     quad = wp.vec3()
     quad[0] = 0.5 * Jaref * Jaref * efc_D
     quad[1] = jv * Jaref * efc_D
     quad[2] = 0.5 * jv * jv * efc_D
-    ctx.quad[efcid] = quad
+    d.efc.quad[efcid] = quad
 
   @kernel
-  def _init_p0_gauss(p0: wp.array(dtype=wp.vec3), ctx: Context):
+  def _init_p0_gauss(p0: wp.array(dtype=wp.vec3), d: types.Data):
     worldid = wp.tid()
-    quad = ctx.quad_gauss[worldid]
+    quad = d.efc.quad_gauss[worldid]
     p0[worldid] = wp.vec3(quad[0], quad[1], 2.0 * quad[2])
 
   @kernel
-  def _init_p0(p0: wp.array(dtype=wp.vec3), d: types.Data, ctx: Context):
+  def _init_p0(p0: wp.array(dtype=wp.vec3), d: types.Data):
     efcid = wp.tid()
 
     if efcid >= d.nefc_total[0]:
       return
 
     # TODO(team): active and conditionally active constraints:
-    if ctx.Jaref[efcid] >= 0.0:
+    if d.efc.Jaref[efcid] >= 0.0:
       return
 
-    worldid = d.efc_worldid[efcid]
-    quad = ctx.quad[efcid]
+    worldid = d.efc.worldid[efcid]
+    quad = d.efc.quad[efcid]
     wp.atomic_add(p0, worldid, wp.vec3(quad[0], quad[1], 2.0 * quad[2]))
 
   @kernel
@@ -401,13 +339,13 @@ def _linesearch_iterative(m: types.Model, d: types.Data, ctx: Context):
     p0: wp.array(dtype=wp.vec3),
     lo: wp.array(dtype=wp.vec3),
     lo_alpha: wp.array(dtype=wp.float32),
-    ctx: Context,
+    d: types.Data,
   ):
     worldid = wp.tid()
 
     pp0 = p0[worldid]
     alpha = -_safe_div(pp0[1], pp0[2])
-    lo[worldid] = _eval_pt(ctx.quad_gauss[worldid], alpha)
+    lo[worldid] = _eval_pt(d.efc.quad_gauss[worldid], alpha)
     lo_alpha[worldid] = alpha
 
   @kernel
@@ -415,19 +353,18 @@ def _linesearch_iterative(m: types.Model, d: types.Data, ctx: Context):
     lo: wp.array(dtype=wp.vec3),
     lo_alpha: wp.array(dtype=wp.float32),
     d: types.Data,
-    ctx: Context,
   ):
     efcid = wp.tid()
 
     if efcid >= d.nefc_total[0]:
       return
 
-    worldid = d.efc_worldid[efcid]
+    worldid = d.efc.worldid[efcid]
     alpha = lo_alpha[worldid]
 
     # TODO(team): active and conditionally active constraints
-    if ctx.Jaref[efcid] + alpha * ctx.jv[efcid] < 0.0:
-      wp.atomic_add(lo, worldid, _eval_pt(ctx.quad[efcid], alpha))
+    if d.efc.Jaref[efcid] + alpha * d.efc.jv[efcid] < 0.0:
+      wp.atomic_add(lo, worldid, _eval_pt(d.efc.quad[efcid], alpha))
 
   @kernel
   def _init_bounds(
@@ -460,14 +397,14 @@ def _linesearch_iterative(m: types.Model, d: types.Data, ctx: Context):
     hi_next_alpha: wp.array(dtype=wp.float32),
     mid: wp.array(dtype=wp.vec3),
     mid_alpha: wp.array(dtype=wp.float32),
-    ctx: Context,
+    d: types.Data,
   ):
     worldid = wp.tid()
 
     if done[worldid]:
       return
 
-    quad = ctx.quad_gauss[worldid]
+    quad = d.efc.quad_gauss[worldid]
 
     plo = lo[worldid]
     plo_alpha = lo_alpha[worldid]
@@ -495,21 +432,20 @@ def _linesearch_iterative(m: types.Model, d: types.Data, ctx: Context):
     mid: wp.array(dtype=wp.vec3),
     mid_alpha: wp.array(dtype=wp.float32),
     d: types.Data,
-    ctx: Context,
   ):
     efcid = wp.tid()
 
     if efcid >= d.nefc_total[0]:
       return
 
-    worldid = d.efc_worldid[efcid]
+    worldid = d.efc.worldid[efcid]
 
     if done[worldid]:
       return
 
-    quad = ctx.quad[efcid]
-    jaref = ctx.Jaref[efcid]
-    jv = ctx.jv[efcid]
+    quad = d.efc.quad[efcid]
+    jaref = d.efc.Jaref[efcid]
+    jv = d.efc.jv[efcid]
 
     alpha = lo_next_alpha[worldid]
     # TODO(team): active and conditionally active constraints
@@ -540,7 +476,7 @@ def _linesearch_iterative(m: types.Model, d: types.Data, ctx: Context):
     hi_next_alpha: wp.array(dtype=wp.float32),
     mid: wp.array(dtype=wp.vec3),
     mid_alpha: wp.array(dtype=wp.float32),
-    ctx: Context,
+    d: types.Data,
   ):
     worldid = wp.tid()
 
@@ -588,7 +524,7 @@ def _linesearch_iterative(m: types.Model, d: types.Data, ctx: Context):
 
     # if we did not adjust the interval, we are done
     # also done if either low or hi slope is nearly flat
-    gtol = ctx.gtol[worldid]
+    gtol = d.efc.gtol[worldid]
     done[worldid] = (
       (not swap_lo and not swap_hi)
       or (plo[1] < 0 and plo[1] > -gtol)
@@ -602,68 +538,69 @@ def _linesearch_iterative(m: types.Model, d: types.Data, ctx: Context):
     plo_better = plo[0] < phi[0]
     alpha = wp.select(improved and plo_better, alpha, plo_alpha)
     alpha = wp.select(improved and not plo_better, alpha, phi_alpha)
-    ctx.alpha[worldid] = alpha
+    d.efc.alpha[worldid] = alpha
 
   @kernel
-  def _qacc_ma(d: types.Data, ctx: Context):
+  def _qacc_ma(d: types.Data):
     worldid, dofid = wp.tid()
-    alpha = ctx.alpha[worldid]
-    d.qacc[worldid, dofid] += alpha * ctx.search[worldid, dofid]
-    ctx.Ma[worldid, dofid] += alpha * ctx.mv[worldid, dofid]
+    alpha = d.efc.alpha[worldid]
+    d.qacc[worldid, dofid] += alpha * d.efc.search[worldid, dofid]
+    d.efc.Ma[worldid, dofid] += alpha * d.efc.mv[worldid, dofid]
 
   @kernel
-  def _jaref(d: types.Data, ctx: Context):
+  def _jaref(d: types.Data):
     efcid = wp.tid()
 
     if efcid >= d.nefc_total[0]:
       return
 
-    ctx.Jaref[efcid] += ctx.alpha[d.efc_worldid[efcid]] * ctx.jv[efcid]
+    d.efc.Jaref[efcid] += d.efc.alpha[d.efc.worldid[efcid]] * d.efc.jv[efcid]
 
-  wp.launch(_gtol, dim=(d.nworld,), inputs=[m, ctx])
+  wp.launch(_gtol, dim=(d.nworld,), inputs=[m, d])
 
   # mv = qM @ search
-  support.mul_m(m, d, ctx.mv, ctx.search)
+  support.mul_m(m, d, d.efc.mv, d.efc.search)
 
   # jv = efc_J @ search
   # TODO(team): is there a better way of doing batched matmuls with dynamic array sizes?
-  ctx.jv.zero_()
+  d.efc.jv.zero_()
 
-  wp.launch(_jv, dim=(d.njmax, m.nv), inputs=[d, ctx])
+  wp.launch(_jv, dim=(d.njmax, m.nv), inputs=[d])
 
   # prepare quadratics
   # quad_gauss = [gauss, search.T @ Ma - search.T @ qfrc_smooth, 0.5 * search.T @ mv]
-  ctx.quad_gauss.zero_()
+  d.efc.quad_gauss.zero_()
 
-  wp.launch(_init_quad_gauss, dim=(d.nworld, m.nv), inputs=[m, d, ctx])
+  wp.launch(_init_quad_gauss, dim=(d.nworld, m.nv), inputs=[m, d])
 
   # quad = [0.5 * Jaref * Jaref * efc_D, jv * Jaref * efc_D, 0.5 * jv * jv * efc_D]
 
-  wp.launch(_init_quad, dim=(d.njmax), inputs=[d, ctx])
+  wp.launch(_init_quad, dim=(d.njmax), inputs=[d])
 
   # linesearch points
-  done = wp.zeros(shape=(d.nworld,), dtype=bool)
-  p0 = wp.empty(shape=(d.nworld,), dtype=wp.vec3)
-  lo = wp.empty(shape=(d.nworld,), dtype=wp.vec3)
-  lo_alpha = wp.empty(shape=(d.nworld,), dtype=wp.float32)
-  hi = wp.empty(shape=(d.nworld,), dtype=wp.vec3)
-  hi_alpha = wp.empty(shape=(d.nworld,), dtype=wp.float32)
-  lo_next = wp.empty(shape=(d.nworld,), dtype=wp.vec3)
-  lo_next_alpha = wp.empty(shape=(d.nworld,), dtype=wp.float32)
-  hi_next = wp.empty(shape=(d.nworld,), dtype=wp.vec3)
-  hi_next_alpha = wp.empty(shape=(d.nworld,), dtype=wp.float32)
-  mid = wp.empty(shape=(d.nworld,), dtype=wp.vec3)
-  mid_alpha = wp.empty(shape=(d.nworld,), dtype=wp.float32)
+  done = d.efc.ls_done
+  done.zero_()
+  p0 = d.efc.p0
+  lo = d.efc.lo
+  lo_alpha = d.efc.lo_alpha
+  hi = d.efc.hi
+  hi_alpha = d.efc.hi_alpha
+  lo_next = d.efc.lo_next
+  lo_next_alpha = d.efc.lo_next_alpha
+  hi_next = d.efc.hi_next
+  hi_next_alpha = d.efc.hi_next_alpha
+  mid = d.efc.mid
+  mid_alpha = d.efc.mid_alpha
 
   # initialize interval
 
-  wp.launch(_init_p0_gauss, dim=(d.nworld,), inputs=[p0, ctx])
+  wp.launch(_init_p0_gauss, dim=(d.nworld,), inputs=[p0, d])
 
-  wp.launch(_init_p0, dim=(d.njmax,), inputs=[p0, d, ctx])
+  wp.launch(_init_p0, dim=(d.njmax,), inputs=[p0, d])
 
-  wp.launch(_init_lo_gauss, dim=(d.nworld,), inputs=[p0, lo, lo_alpha, ctx])
+  wp.launch(_init_lo_gauss, dim=(d.nworld,), inputs=[p0, lo, lo_alpha, d])
 
-  wp.launch(_init_lo, dim=(d.njmax,), inputs=[lo, lo_alpha, d, ctx])
+  wp.launch(_init_lo, dim=(d.njmax,), inputs=[lo, lo_alpha, d])
 
   # set the lo/hi interval bounds
 
@@ -674,20 +611,20 @@ def _linesearch_iterative(m: types.Model, d: types.Data, ctx: Context):
     # this allows us to preserve cudagraph requirements (no dynamic kernel launching) at the expense
     # of extra launches
     inputs = [done, lo, lo_alpha, hi, hi_alpha, lo_next, lo_next_alpha, hi_next]
-    inputs += [hi_next_alpha, mid, mid_alpha, ctx]
+    inputs += [hi_next_alpha, mid, mid_alpha, d]
     wp.launch(_next_alpha_gauss, dim=(d.nworld,), inputs=inputs)
 
     inputs = [done, lo_next, lo_next_alpha, hi_next, hi_next_alpha, mid, mid_alpha]
-    inputs += [d, ctx]
+    inputs += [d]
     wp.launch(_next_quad, dim=(d.njmax,), inputs=inputs)
 
     inputs = [done, p0, lo, lo_alpha, hi, hi_alpha, lo_next, lo_next_alpha, hi_next]
-    inputs += [hi_next_alpha, mid, mid_alpha, ctx]
+    inputs += [hi_next_alpha, mid, mid_alpha, d]
     wp.launch(_swap, dim=(d.nworld,), inputs=inputs)
 
-  wp.launch(_qacc_ma, dim=(d.nworld, m.nv), inputs=[d, ctx])
+  wp.launch(_qacc_ma, dim=(d.nworld, m.nv), inputs=[d])
 
-  wp.launch(_jaref, dim=(d.njmax,), inputs=[d, ctx])
+  wp.launch(_jaref, dim=(d.njmax,), inputs=[d])
 
 
 @event_scope
@@ -695,91 +632,92 @@ def solve(m: types.Model, d: types.Data):
   """Finds forces that satisfy constraints."""
 
   @kernel
-  def _zero_search_dot(ctx: Context):
+  def _zero_search_dot(d: types.Data):
     worldid = wp.tid()
-    ctx.search_dot[worldid] = 0.0
+    d.efc.search_dot[worldid] = 0.0
 
   @kernel
-  def _search_update(ctx: Context):
+  def _search_update(d: types.Data):
     worldid, dofid = wp.tid()
-    search = -1.0 * ctx.Mgrad[worldid, dofid]
+    search = -1.0 * d.efc.Mgrad[worldid, dofid]
 
     if wp.static(m.opt.solver == mujoco.mjtSolver.mjSOL_CG):
-      search += ctx.beta[worldid] * ctx.search[worldid, dofid]
+      search += d.efc.beta[worldid] * d.efc.search[worldid, dofid]
 
-    ctx.search[worldid, dofid] = search
-    wp.atomic_add(ctx.search_dot, worldid, search * search)
+    d.efc.search[worldid, dofid] = search
+    wp.atomic_add(d.efc.search_dot, worldid, search * search)
 
   @kernel
-  def _done(ctx: Context, m: types.Model, solver_niter: int):
+  def _done(m: types.Model, d: types.Data, solver_niter: int):
     worldid = wp.tid()
-    improvement = _rescale(m, ctx.prev_cost[worldid] - ctx.cost[worldid])
-    gradient = _rescale(m, wp.math.sqrt(ctx.grad_dot[worldid]))
+    improvement = _rescale(m, d.efc.prev_cost[worldid] - d.efc.cost[worldid])
+    gradient = _rescale(m, wp.math.sqrt(d.efc.grad_dot[worldid]))
     done = solver_niter >= m.opt.iterations
     done = done or (improvement < m.opt.tolerance)
     done = done or (gradient < m.opt.tolerance)
-    ctx.done[worldid] = int(done)
+    d.efc.done[worldid] = int(done)
 
   if m.opt.solver == mujoco.mjtSolver.mjSOL_CG:
 
     @kernel
-    def _prev_grad_Mgrad(ctx: Context):
+    def _prev_grad_Mgrad(d: types.Data):
       worldid, dofid = wp.tid()
-      ctx.prev_grad[worldid, dofid] = ctx.grad[worldid, dofid]
-      ctx.prev_Mgrad[worldid, dofid] = ctx.Mgrad[worldid, dofid]
+      d.efc.prev_grad[worldid, dofid] = d.efc.grad[worldid, dofid]
+      d.efc.prev_Mgrad[worldid, dofid] = d.efc.Mgrad[worldid, dofid]
 
     @kernel
-    def _zero_beta_num_den(ctx: Context):
+    def _zero_beta_num_den(d: types.Data):
       worldid = wp.tid()
-      ctx.beta_num[worldid] = 0.0
-      ctx.beta_den[worldid] = 0.0
+      d.efc.beta_num[worldid] = 0.0
+      d.efc.beta_den[worldid] = 0.0
 
     @kernel
-    def _beta_num_den(ctx: Context):
+    def _beta_num_den(d: types.Data):
       worldid, dofid = wp.tid()
-      prev_Mgrad = ctx.prev_Mgrad[worldid][dofid]
+      prev_Mgrad = d.efc.prev_Mgrad[worldid][dofid]
       wp.atomic_add(
-        ctx.beta_num,
+        d.efc.beta_num,
         worldid,
-        ctx.grad[worldid, dofid] * (ctx.Mgrad[worldid, dofid] - prev_Mgrad),
+        d.efc.grad[worldid, dofid] * (d.efc.Mgrad[worldid, dofid] - prev_Mgrad),
       )
-      wp.atomic_add(ctx.beta_den, worldid, ctx.prev_grad[worldid, dofid] * prev_Mgrad)
+      wp.atomic_add(
+        d.efc.beta_den, worldid, d.efc.prev_grad[worldid, dofid] * prev_Mgrad
+      )
 
     @kernel
-    def _beta(ctx: Context):
+    def _beta(d: types.Data):
       worldid = wp.tid()
-      ctx.beta[worldid] = wp.max(
-        0.0, ctx.beta_num[worldid] / wp.max(mujoco.mjMINVAL, ctx.beta_den[worldid])
+      d.efc.beta[worldid] = wp.max(
+        0.0, d.efc.beta_num[worldid] / wp.max(mujoco.mjMINVAL, d.efc.beta_den[worldid])
       )
 
   # warmstart
   wp.copy(d.qacc, d.qacc_warmstart)
 
-  ctx = _context(m, d)
-  _create_context(ctx, m, d, grad=True)
+  _create_context(m, d, grad=True)
 
   for i in range(m.opt.iterations):
-    _linesearch_iterative(m, d, ctx)
+    _linesearch_iterative(m, d)
 
     if m.opt.solver == mujoco.mjtSolver.mjSOL_CG:
-      wp.launch(_prev_grad_Mgrad, dim=(d.nworld, m.nv), inputs=[ctx])
+      wp.launch(_prev_grad_Mgrad, dim=(d.nworld, m.nv), inputs=[d])
 
-    _update_constraint(m, d, ctx)
-    _update_gradient(m, d, ctx)
+    _update_constraint(m, d)
+    _update_gradient(m, d)
 
     # polak-ribiere
     if m.opt.solver == mujoco.mjtSolver.mjSOL_CG:
-      wp.launch(_zero_beta_num_den, dim=(d.nworld), inputs=[ctx])
+      wp.launch(_zero_beta_num_den, dim=(d.nworld), inputs=[d])
 
-      wp.launch(_beta_num_den, dim=(d.nworld, m.nv), inputs=[ctx])
+      wp.launch(_beta_num_den, dim=(d.nworld, m.nv), inputs=[d])
 
-      wp.launch(_beta, dim=(d.nworld,), inputs=[ctx])
+      wp.launch(_beta, dim=(d.nworld,), inputs=[d])
 
-    wp.launch(_zero_search_dot, dim=(d.nworld), inputs=[ctx])
+    wp.launch(_zero_search_dot, dim=(d.nworld), inputs=[d])
 
-    wp.launch(_search_update, dim=(d.nworld, m.nv), inputs=[ctx])
+    wp.launch(_search_update, dim=(d.nworld, m.nv), inputs=[d])
 
-    wp.launch(_done, dim=(d.nworld,), inputs=[ctx, m, i])
+    wp.launch(_done, dim=(d.nworld,), inputs=[m, d, i])
     # TODO(team): return if all done
 
   wp.copy(d.qacc_warmstart, d.qacc)

--- a/mujoco/mjx/_src/solver.py
+++ b/mujoco/mjx/_src/solver.py
@@ -225,7 +225,7 @@ def _update_gradient(m: types.Model, d: types.Data):
   wp.launch(_grad, dim=(d.nworld, m.nv), inputs=[d])
 
   if m.opt.solver == mujoco.mjtSolver.mjSOL_CG:
-    smooth.solve_m(m, d, ctx.Mgrad, ctx.grad)
+    smooth.solve_m(m, d, d.efc.Mgrad, d.efc.grad)
   elif m.opt.solver == mujoco.mjtSolver.mjSOL_NEWTON:
     # h = qM + (efc_J.T * efc_D * active) @ efc_J
     if m.opt.is_sparse:

--- a/mujoco/mjx/_src/solver_test.py
+++ b/mujoco/mjx/_src/solver_test.py
@@ -76,10 +76,9 @@ class SolverTest(parameterized.TestCase):
 
       mj_cost = cost(mjd.qacc)
 
-      ctx = solver._context(m, d)
-      solver._create_context(ctx, m, d)
+      solver._create_context(m, d)
 
-      mjx_cost = ctx.cost.numpy()[0] - ctx.gauss.numpy()[0]
+      mjx_cost = d.efc.cost.numpy()[0] - d.efc.gauss.numpy()[0]
 
       _assert_eq(mjx_cost, mj_cost, name="cost")
 
@@ -91,7 +90,7 @@ class SolverTest(parameterized.TestCase):
       d = io.put_data(mjm, mjd, njmax=mjd.nefc)
       d.qacc.zero_()
       d.qfrc_constraint.zero_()
-      d.efc_force.zero_()
+      d.efc.force.zero_()
 
       if solver_ == mujoco.mjtSolver.mjSOL_CG:
         smooth.factor_m(m, d)
@@ -104,7 +103,7 @@ class SolverTest(parameterized.TestCase):
       if m.opt.solver == mujoco.mjtSolver.mjSOL_NEWTON:
         _assert_eq(d.qacc.numpy()[0], mjd.qacc, "qacc")
         _assert_eq(d.qfrc_constraint.numpy()[0], mjd.qfrc_constraint, "qfrc_constraint")
-        _assert_eq(d.efc_force.numpy()[: mjd.nefc], mjd.efc_force, "efc_force")
+        _assert_eq(d.efc.force.numpy()[: mjd.nefc], mjd.efc_force, "efc_force")
 
   @parameterized.parameters(
     (mujoco.mjtCone.mjCONE_PYRAMIDAL, mujoco.mjtSolver.mjSOL_CG, 25, 5),
@@ -227,10 +226,10 @@ class SolverTest(parameterized.TestCase):
     d.qM = wp.from_numpy(qM, dtype=wp.float32)
     d.qacc_smooth = wp.from_numpy(qacc_smooth, dtype=wp.float32)
     d.qfrc_smooth = wp.from_numpy(qfrc_smooth, dtype=wp.float32)
-    d.efc_J = wp.from_numpy(efc_J_fill, dtype=wp.float32)
-    d.efc_D = wp.from_numpy(efc_D_fill, dtype=wp.float32)
-    d.efc_aref = wp.from_numpy(efc_aref_fill, dtype=wp.float32)
-    d.efc_worldid = wp.from_numpy(efc_worldid, dtype=wp.int32)
+    d.efc.J = wp.from_numpy(efc_J_fill, dtype=wp.float32)
+    d.efc.D = wp.from_numpy(efc_D_fill, dtype=wp.float32)
+    d.efc.aref = wp.from_numpy(efc_aref_fill, dtype=wp.float32)
+    d.efc.worldid = wp.from_numpy(efc_worldid, dtype=wp.int32)
 
     if solver_ == mujoco.mjtSolver.mjSOL_CG:
       m0 = io.put_model(mjm0)
@@ -253,7 +252,7 @@ class SolverTest(parameterized.TestCase):
 
     d.qacc.zero_()
     d.qfrc_constraint.zero_()
-    d.efc_force.zero_()
+    d.efc.force.zero_()
     solver.solve(m, d)
 
     def cost(m, d, qacc):
@@ -285,17 +284,17 @@ class SolverTest(parameterized.TestCase):
       _assert_eq(d.qfrc_constraint.numpy()[2], mjd2.qfrc_constraint, "qfrc_constraint2")
 
       _assert_eq(
-        d.efc_force.numpy()[: mjd0.nefc],
+        d.efc.force.numpy()[: mjd0.nefc],
         mjd0.efc_force,
         "efc_force0",
       )
       _assert_eq(
-        d.efc_force.numpy()[mjd0.nefc : mjd0.nefc + mjd1.nefc],
+        d.efc.force.numpy()[mjd0.nefc : mjd0.nefc + mjd1.nefc],
         mjd1.efc_force,
         "efc_force1",
       )
       _assert_eq(
-        d.efc_force.numpy()[mjd0.nefc + mjd1.nefc : mjd0.nefc + mjd1.nefc + mjd2.nefc],
+        d.efc.force.numpy()[mjd0.nefc + mjd1.nefc : mjd0.nefc + mjd1.nefc + mjd2.nefc],
         mjd2.efc_force,
         "efc_force2",
       )

--- a/mujoco/mjx/_src/types.py
+++ b/mujoco/mjx/_src/types.py
@@ -221,6 +221,57 @@ class Statistic:
 
 
 @wp.struct
+class Constraint:
+  # efc
+  J: wp.array(dtype=wp.float32, ndim=2)
+  D: wp.array(dtype=wp.float32, ndim=1)
+  pos: wp.array(dtype=wp.float32, ndim=1)
+  aref: wp.array(dtype=wp.float32, ndim=1)
+  force: wp.array(dtype=wp.float32, ndim=1)
+  margin: wp.array(dtype=wp.float32, ndim=1)
+  worldid: wp.array(dtype=wp.int32, ndim=1)  # warp only
+  # solver context
+  Jaref: wp.array(dtype=wp.float32, ndim=1)
+  Ma: wp.array(dtype=wp.float32, ndim=2)
+  grad: wp.array(dtype=wp.float32, ndim=2)
+  grad_dot: wp.array(dtype=wp.float32, ndim=1)
+  Mgrad: wp.array(dtype=wp.float32, ndim=2)
+  search: wp.array(dtype=wp.float32, ndim=2)
+  search_dot: wp.array(dtype=wp.float32, ndim=1)
+  gauss: wp.array(dtype=wp.float32, ndim=1)
+  cost: wp.array(dtype=wp.float32, ndim=1)
+  prev_cost: wp.array(dtype=wp.float32, ndim=1)
+  solver_niter: wp.array(dtype=wp.int32, ndim=1)
+  active: wp.array(dtype=wp.int32, ndim=1)
+  gtol: wp.array(dtype=wp.float32, ndim=1)
+  mv: wp.array(dtype=wp.float32, ndim=2)
+  jv: wp.array(dtype=wp.float32, ndim=1)
+  quad: wp.array(dtype=wp.vec3f, ndim=1)
+  quad_gauss: wp.array(dtype=wp.vec3f, ndim=1)
+  h: wp.array(dtype=wp.float32, ndim=3)
+  alpha: wp.array(dtype=wp.float32, ndim=1)
+  prev_grad: wp.array(dtype=wp.float32, ndim=2)
+  prev_Mgrad: wp.array(dtype=wp.float32, ndim=2)
+  beta: wp.array(dtype=wp.float32, ndim=1)
+  beta_num: wp.array(dtype=wp.float32, ndim=1)
+  beta_den: wp.array(dtype=wp.float32, ndim=1)
+  done: wp.array(dtype=wp.int32, ndim=1)
+  # linesearch
+  ls_done: wp.array(dtype=bool, ndim=1)
+  p0: wp.array(dtype=wp.vec3, ndim=1)
+  lo: wp.array(dtype=wp.vec3, ndim=1)
+  lo_alpha: wp.array(dtype=wp.float32, ndim=1)
+  hi: wp.array(dtype=wp.vec3, ndim=1)
+  hi_alpha: wp.array(dtype=wp.float32, ndim=1)
+  lo_next: wp.array(dtype=wp.vec3, ndim=1)
+  lo_next_alpha: wp.array(dtype=wp.float32, ndim=1)
+  hi_next: wp.array(dtype=wp.vec3, ndim=1)
+  hi_next_alpha: wp.array(dtype=wp.float32, ndim=1)
+  mid: wp.array(dtype=wp.vec3, ndim=1)
+  mid_alpha: wp.array(dtype=wp.float32, ndim=1)
+
+
+@wp.struct
 class Model:
   nq: int
   nv: int
@@ -409,15 +460,9 @@ class Data:
   qfrc_actuator: wp.array(dtype=wp.float32, ndim=2)
   qfrc_smooth: wp.array(dtype=wp.float32, ndim=2)
   qacc_smooth: wp.array(dtype=wp.float32, ndim=2)
-  efc_J: wp.array(dtype=wp.float32, ndim=2)
-  efc_D: wp.array(dtype=wp.float32, ndim=1)
-  efc_pos: wp.array(dtype=wp.float32, ndim=1)
-  efc_aref: wp.array(dtype=wp.float32, ndim=1)
-  efc_force: wp.array(dtype=wp.float32, ndim=1)
-  efc_margin: wp.array(dtype=wp.float32, ndim=1)
-  efc_worldid: wp.array(dtype=wp.int32, ndim=1)  # warp only
   xfrc_applied: wp.array(dtype=wp.spatial_vector, ndim=2)
   contact: Contact
+  efc: Constraint
 
   # temp arrays
   qfrc_integration: wp.array(dtype=wp.float32, ndim=2)


### PR DESCRIPTION
```
mjx-testspeed --function=solve --mjcf=humanoid/humanoid.xml --batch_size=8192 --solver=newton
```

this pr:
```
Summary for 8192 parallel rollouts

 Total JIT time: 0.18 s
 Total simulation time: 7.96 s
 Total steps per second: 1,029,715
 Total realtime factor: 5,148.57 x
 Total time per step: 971.14 ns
```

main:
```
Summary for 8192 parallel rollouts

 Total JIT time: 0.18 s
 Total simulation time: 8.11 s
 Total steps per second: 1,009,871
 Total realtime factor: 5,049.36 x
 Total time per step: 990.23 ns
```