### PR TITLE
Add proper plane support for the sweep and prune broad phase

### DIFF
--- a/mujoco_warp/_src/broad_phase_test.py
+++ b/mujoco_warp/_src/broad_phase_test.py
@@ -150,14 +150,6 @@ class BroadPhaseTest(parameterized.TestCase):
       d.nworld, m.ngeom, pos, m.geom_rbound.numpy(), m.geom_margin.numpy(), m.geom_bodyid.numpy()
     )
 
-<<<<<<< HEAD
-    result = d.broadphase_pairs
-    broadphase_result_count = d.broadphase_result_count
-
-    # Get numpy arrays from result and broadphase_result_count
-    result_np = result.numpy()
-    broadphase_result_count_np = broadphase_result_count.numpy()
-=======
     ncollision = dx.ncollision.numpy()[0]
     np.testing.assert_equal(ncollision, len(brute_force_overlaps[0]), "ncollision")
 
@@ -166,25 +158,11 @@ class BroadPhaseTest(parameterized.TestCase):
     # Get numpy arrays from result and ncollision
     result_np = d.collision_pair.numpy()
     worldid_np = d.collision_worldid.numpy()
->>>>>>> main
 
     # Iterate over each world
     for world_idx in range(d.nworld):
       # Get number of collisions for this world
-<<<<<<< HEAD
-      num_collisions = broadphase_result_count_np[world_idx]
-       
-      # print(len(brute_force_overlaps[world_idx]))
-      # print(num_collisions)
-      # print(brute_force_overlaps)
-      # print(result)
-
-      num_collisions = broadphase_result_count_np[world_idx]
-      print(f"Number of collisions for world {world_idx}: {num_collisions}")
-
-=======
       num_collisions = np.sum(worldid_np[:ncollision] == world_idx)
->>>>>>> main
       list = brute_force_overlaps[world_idx]
       np.testing.assert_equal(len(list), num_collisions, "num_collisions")
 

--- a/mujoco_warp/_src/collision_driver.py
+++ b/mujoco_warp/_src/collision_driver.py
@@ -563,7 +563,7 @@ def broadphase(m: Model, d: Data):
   # broadphase collision
 
   # TODO(team): determine ngeom to switch from n^2 to sap
-  if m.ngeom <= 1:
+  if m.ngeom <= 100:
     nxn_broadphase(m, d)
   else:
     broadphase_sweep_and_prune(m, d)

--- a/mujoco_warp/_src/collision_driver.py
+++ b/mujoco_warp/_src/collision_driver.py
@@ -74,12 +74,11 @@ def broadphase_project_spheres_onto_sweep_direction_kernel(
   sphere_radius = r + m.geom_margin[i]
 
   center = wp.dot(direction, c)
-  d_val = 0.5 * sphere_radius
-  f = center - d_val
+  f = center - sphere_radius
 
   # Store results in the data arrays
   d.box_projections_lower[worldId, i] = f
-  d.box_projections_upper[worldId, i] = center + d_val
+  d.box_projections_upper[worldId, i] = center + sphere_radius
   d.box_sorting_indexer[worldId, i] = i
 
   if i == 0:
@@ -139,7 +138,7 @@ def reorder_bounding_spheres_kernel(
   # Get the bounding volume
   c = d.geom_xpos[worldId, mapped]
   r = m.geom_rbound[mapped]
-  margin = wp.abs(m.geom_margin[mapped])
+  margin = m.geom_margin[mapped]
 
   # Reorder the box into the sorted array
   if r == 0.0:
@@ -392,7 +391,7 @@ def create_segmented_sort_kernel(ngeom: int):
 def broadphase_sweep_and_prune(m: Model, d: Data):
   """Broad-phase collision detection via sweep-and-prune."""
 
-  # Use randomfixed direction vector for now
+  # Use random fixed direction vector for now
   direction = wp.vec3(0.5935, 0.7790, 0.1235)
   direction = wp.normalize(direction)
 

--- a/mujoco_warp/_src/collision_driver.py
+++ b/mujoco_warp/_src/collision_driver.py
@@ -58,127 +58,23 @@ def _geom_pair(m: Model, geom1: int, geom2: int) -> wp.vec2i:
     return wp.vec2i(geom1, geom2)
 
 
-# @wp.struct
-# class AABB:
-#   min: wp.vec3
-#   max: wp.vec3
-
-
-# @wp.func
-# def transform_aabb(
-#   aabb_pos: wp.vec3, aabb_size: wp.vec3, pos: wp.vec3, ori: wp.mat33
-# ) -> AABB:
-#   aabb = AABB()
-#   aabb.max = wp.vec3(-1000000000.0, -1000000000.0, -1000000000.0)
-#   aabb.min = wp.vec3(1000000000.0, 1000000000.0, 1000000000.0)
-
-#   for i in range(8):
-#     corner = wp.vec3(aabb_size.x * 0.5, aabb_size.y * 0.5, aabb_size.z * 0.5)
-#     if i % 2 == 0:
-#       corner.x = -corner.x
-#     if (i // 2) % 2 == 0:
-#       corner.y = -corner.y
-#     if i < 4:
-#       corner.z = -corner.z
-#     corner_world = ori * (corner + aabb_pos) + pos
-#     aabb.max = wp.max(aabb.max, corner_world)
-#     aabb.min = wp.min(aabb.min, corner_world)
-
-#   return aabb
-
-
-# @wp.kernel
-# def get_dyn_geom_aabb(
-#   m: Model,
-#   d: Data,
-# ):
-#   env_id, gid = wp.tid()
-
-#   pos = d.geom_xpos[env_id, gid]
-#   ori = d.geom_xmat[env_id, gid]
-
-#   aabb_pos = m.geom_aabb[gid, 0]
-#   aabb_size = m.geom_aabb[gid, 1]
-
-#   aabb = transform_aabb(aabb_pos, aabb_size, pos, ori)
-
-#   # Write results to output
-#   d.dyn_geom_aabb[env_id, gid, 0] = aabb.min
-#   d.dyn_geom_aabb[env_id, gid, 1] = aabb.max
-
-
-# @wp.func
-# def overlap(
-#   world_id: int,
-#   a: int,
-#   b: int,
-#   boxes: wp.array(dtype=wp.vec3, ndim=3),
-# ) -> bool:
-#   # Extract centers and sizes
-#   a_min = boxes[world_id, a, 0]
-#   a_max = boxes[world_id, a, 1]
-#   b_min = boxes[world_id, b, 0]
-#   b_max = boxes[world_id, b, 1]
-
-#   return not (
-#     a_min.x > b_max.x
-#     or b_min.x > a_max.x
-#     or a_min.y > b_max.y
-#     or b_min.y > a_max.y
-#     or a_min.z > b_max.z
-#     or b_min.z > a_max.z
-#   )
-
-
-# @wp.kernel
-# def broadphase_project_boxes_onto_sweep_direction_kernel(
-#   d: Data,
-# ):
-#   worldId, i = wp.tid()
-
-#   box_min = d.dyn_geom_aabb[worldId, i, 0]
-#   box_max = d.dyn_geom_aabb[worldId, i, 1]
-#   c = (box_min + box_max) * 0.5
-#   box_half_size = (box_max - box_min) * 0.5
-
-#   # Use fixed direction vector and its absolute values
-#   direction = wp.vec3(0.5935, 0.7790, 0.1235)
-#   direction = wp.normalize(direction)
-#   abs_dir = wp.vec3(abs(direction.x), abs(direction.y), abs(direction.z))
-
-#   center = wp.dot(direction, c)
-#   d_val = wp.dot(box_half_size, abs_dir)
-#   f = center - d_val
-
-#   # Store results in the data arrays
-#   d.box_projections_lower[worldId, i] = f
-#   d.box_projections_upper[worldId, i] = center + d_val
-#   d.box_sorting_indexer[worldId, i] = i
-
-#   if i == 0:
-#     d.broadphase_result_count[worldId] = 0  # Initialize result count to 0
-
 @wp.kernel
 def broadphase_project_spheres_onto_sweep_direction_kernel(
   m: Model,
   d: Data,
+  direction: wp.vec3,
 ):
   worldId, i = wp.tid()
 
   c = d.geom_xpos[worldId, i]
   r = m.geom_rbound[i]
-  if(r == 0.0):
+  if r == 0.0:
     # current geom is a plane
     r = 1000000000.0
   sphere_radius = r + m.geom_margin[i]
 
-  # Use fixed direction vector and its absolute values
-  direction = wp.vec3(0.5935, 0.7790, 0.1235)
-  direction = wp.normalize(direction)
-  #abs_dir = wp.vec3(abs(direction.x), abs(direction.y), abs(direction.z))
-
   center = wp.dot(direction, c)
-  d_val = 0.5*sphere_radius
+  d_val = 0.5 * sphere_radius
   f = center - d_val
 
   # Store results in the data arrays
@@ -189,51 +85,45 @@ def broadphase_project_spheres_onto_sweep_direction_kernel(
   if i == 0:
     d.broadphase_result_count[worldId] = 0  # Initialize result count to 0
 
-# @wp.kernel
-# def reorder_bounding_boxes_kernel(
-#   d: Data,
-# ):
-#   worldId, i = wp.tid()
 
-#   # Get the index from the data indexer
-#   mapped = d.box_sorting_indexer[worldId, i]
-
-#   # Get the box from the original boxes array
-#   box_min = d.dyn_geom_aabb[worldId, mapped, 0]
-#   box_max = d.dyn_geom_aabb[worldId, mapped, 1]
-
-#   # Reorder the box into the sorted array
-#   d.boxes_sorted[worldId, i, 0] = box_min
-#   d.boxes_sorted[worldId, i, 1] = box_max
+# Define constants for plane types
+PLANE_ZERO_OFFSET = -1.0
+PLANE_NEGATIVE_OFFSET = -2.0
+PLANE_POSITIVE_OFFSET = -3.0
 
 
 @wp.func
 def encode_plane(normal: wp.vec3, point_on_plane: wp.vec3, margin: float) -> wp.vec4:
   normal = wp.normalize(normal)
-  d = -wp.dot(normal, point_on_plane + normal * margin)  
-  w = float(0)
-  s = wp.abs(d)
-  if wp.abs(d) < 1e-6:
-    w = -1.0 # negative w distinguishes planes from spheres
-    s = 1.0
-  elif d < 0.0:
-    w = -2.0 # negative w distinguishes planes from spheres
+  plane_offset = -wp.dot(normal, point_on_plane + normal * margin)
+
+  # Scale factor for the normal
+  scale = wp.abs(plane_offset)
+
+  # Handle special cases
+  if wp.abs(plane_offset) < 1e-6:
+    return wp.vec4(normal.x, normal.y, normal.z, PLANE_ZERO_OFFSET)
+  elif plane_offset < 0.0:
+    return wp.vec4(
+      scale * normal.x, scale * normal.y, scale * normal.z, PLANE_NEGATIVE_OFFSET
+    )
   else:
-    w = -3.0 # negative w distinguishes planes from spheres
-  return wp.vec4(s * normal.x, s * normal.y, s * normal.z, w)
+    return wp.vec4(
+      scale * normal.x, scale * normal.y, scale * normal.z, PLANE_POSITIVE_OFFSET
+    )
 
 
 @wp.func
-def decode_plane(p: wp.vec4) -> wp.vec4:
-  w = wp.length(p)
-  n = wp.normalize(xyz(p))
-  if(p.w == -1.0):
-    return wp.vec4(n.x, n.y, n.z, 0.0)
-  elif(p.w == -2.0):
-    return wp.vec4(n.x, n.y, n.z, -w)
-  else:
-    return wp.vec4(n.x, n.y, n.z, w)
+def decode_plane(encoded: wp.vec4) -> wp.vec4:
+  magnitude = wp.length(encoded)
+  normal = wp.normalize(xyz(encoded))
 
+  if encoded.w == PLANE_ZERO_OFFSET:
+    return wp.vec4(normal.x, normal.y, normal.z, 0.0)
+  elif encoded.w == PLANE_NEGATIVE_OFFSET:
+    return wp.vec4(normal.x, normal.y, normal.z, -magnitude)
+  else:
+    return wp.vec4(normal.x, normal.y, normal.z, magnitude)
 
 
 @wp.kernel
@@ -246,29 +136,32 @@ def reorder_bounding_spheres_kernel(
   # Get the index from the data indexer
   mapped = d.box_sorting_indexer[worldId, i]
 
-  # Get the box from the original boxes array
-  #box_min = d.dyn_geom_aabb[worldId, mapped, 0]
-  #box_max = d.dyn_geom_aabb[worldId, mapped, 1]
+  # Get the bounding volume
   c = d.geom_xpos[worldId, mapped]
   r = m.geom_rbound[mapped]
   margin = wp.abs(m.geom_margin[mapped])
 
   # Reorder the box into the sorted array
-  if(r == 0.0):
+  if r == 0.0:
     # store the plane equation
     xmat = d.geom_xmat[worldId, mapped]
     plane_normal = wp.vec3(xmat[0, 2], xmat[1, 2], xmat[2, 2])
-    d.spheres_sorted[worldId, i] = encode_plane(plane_normal, c, margin) # negative w component is used to disginguish planes from spheres
+    d.spheres_sorted[worldId, i] = encode_plane(
+      plane_normal, c, margin
+    )  # negative w component is used to disginguish planes from spheres
   else:
     d.spheres_sorted[worldId, i] = wp.vec4(c.x, c.y, c.z, r + margin)
+
 
 @wp.func
 def xyz(v: wp.vec4) -> wp.vec3:
   return wp.vec3(v.x, v.y, v.z)
 
+
 @wp.func
 def signed_distance_point_plane(point: wp.vec3, plane: wp.vec4) -> float:
   return wp.dot(point, xyz(plane)) + plane.w
+
 
 @wp.func
 def overlap(
@@ -285,7 +178,7 @@ def overlap(
     # both are planes
     return False
   elif s_a.w < 0.0 or s_b.w < 0.0:
-    if s_b.w < 0.0: # swap if required such that s_a is always a plane
+    if s_b.w < 0.0:  # swap if required such that s_a is always a plane
       tmp = s_a
       s_a = s_b
       s_b = tmp
@@ -298,8 +191,6 @@ def overlap(
     dist_sq = wp.dot(delta, delta)
     radius_sum = s_a.w + s_b.w
     return dist_sq <= radius_sum * radius_sum
-
-
 
 
 @wp.func
@@ -485,11 +376,7 @@ def create_segmented_sort_kernel(ngeom: int):
     worldid, j = wp.tid()
 
     # Load input into shared memory
-    keys = wp.tile_load(
-      d.box_projections_lower[worldid],
-      shape=ngeom,
-      storage="shared",
-    )
+    keys = wp.tile_load(d.box_projections_lower[worldid], shape=ngeom, storage="shared")
     values = wp.tile_load(d.box_sorting_indexer[worldid], shape=ngeom, storage="shared")
 
     # Perform in-place sorting
@@ -505,20 +392,17 @@ def create_segmented_sort_kernel(ngeom: int):
 def broadphase_sweep_and_prune(m: Model, d: Data):
   """Broad-phase collision detection via sweep-and-prune."""
 
-  # generate geom AABBs
-  # wp.launch(
-  #   kernel=get_dyn_geom_aabb,
-  #   dim=(d.nworld, m.ngeom),
-  #   inputs=[m, d],
-  # )
+  # Use randomfixed direction vector for now
+  direction = wp.vec3(0.5935, 0.7790, 0.1235)
+  direction = wp.normalize(direction)
 
   wp.launch(
     kernel=broadphase_project_spheres_onto_sweep_direction_kernel,
     dim=(d.nworld, m.ngeom),
-    inputs=[m, d],
+    inputs=[m, d, direction],
   )
 
-  tile_sort_available = True
+  tile_sort_available = False
   segmented_sort_available = hasattr(wp.utils, "segmented_sort_pairs")
 
   if tile_sort_available:
@@ -534,57 +418,57 @@ def broadphase_sweep_and_prune(m: Model, d: Data):
       m.ngeom * d.nworld,
       d.segment_indices,
     )
-  # else:
-  #   # Sort each world's segment separately
-  #   for world_id in range(d.nworld):
-  #     start_idx = world_id * m.ngeom
+  else:
+    # Sort each world's segment separately
+    for world_id in range(d.nworld):
+      start_idx = world_id * m.ngeom
 
-  #     # Create temporary arrays for sorting
-  #     temp_box_projections_lower = wp.zeros(
-  #       m.ngeom * 2,
-  #       dtype=d.box_projections_lower.dtype,
-  #     )
-  #     temp_box_sorting_indexer = wp.zeros(
-  #       m.ngeom * 2,
-  #       dtype=d.box_sorting_indexer.dtype,
-  #     )
+      # Create temporary arrays for sorting
+      temp_box_projections_lower = wp.zeros(
+        m.ngeom * 2,
+        dtype=d.box_projections_lower.dtype,
+      )
+      temp_box_sorting_indexer = wp.zeros(
+        m.ngeom * 2,
+        dtype=d.box_sorting_indexer.dtype,
+      )
 
-  #     # Copy data to temporary arrays
-  #     wp.copy(
-  #       temp_box_projections_lower,
-  #       d.box_projections_lower,
-  #       0,
-  #       start_idx,
-  #       m.ngeom,
-  #     )
-  #     wp.copy(
-  #       temp_box_sorting_indexer,
-  #       d.box_sorting_indexer,
-  #       0,
-  #       start_idx,
-  #       m.ngeom,
-  #     )
+      # Copy data to temporary arrays
+      wp.copy(
+        temp_box_projections_lower,
+        d.box_projections_lower,
+        0,
+        start_idx,
+        m.ngeom,
+      )
+      wp.copy(
+        temp_box_sorting_indexer,
+        d.box_sorting_indexer,
+        0,
+        start_idx,
+        m.ngeom,
+      )
 
-  #     # Sort the temporary arrays
-  #     wp.utils.radix_sort_pairs(
-  #       temp_box_projections_lower, temp_box_sorting_indexer, m.ngeom
-  #     )
+      # Sort the temporary arrays
+      wp.utils.radix_sort_pairs(
+        temp_box_projections_lower, temp_box_sorting_indexer, m.ngeom
+      )
 
-  #     # Copy sorted data back
-  #     wp.copy(
-  #       d.box_projections_lower,
-  #       temp_box_projections_lower,
-  #       start_idx,
-  #       0,
-  #       m.ngeom,
-  #     )
-  #     wp.copy(
-  #       d.box_sorting_indexer,
-  #       temp_box_sorting_indexer,
-  #       start_idx,
-  #       0,
-  #       m.ngeom,
-  #     )
+      # Copy sorted data back
+      wp.copy(
+        d.box_projections_lower,
+        temp_box_projections_lower,
+        start_idx,
+        0,
+        m.ngeom,
+      )
+      wp.copy(
+        d.box_sorting_indexer,
+        temp_box_sorting_indexer,
+        start_idx,
+        0,
+        m.ngeom,
+      )
 
   wp.launch(
     kernel=reorder_bounding_spheres_kernel,
@@ -639,7 +523,7 @@ def nxn_broadphase(m: Model, d: Data):
     margin1 = m.geom_margin[geom1]
     margin2 = m.geom_margin[geom2]
     pos1 = d.geom_xpos[worldid, geom1]
-    pos2 = d.geom_xpos[worldid, geom2]    
+    pos2 = d.geom_xpos[worldid, geom2]
     size1 = m.geom_rbound[geom1]
     size2 = m.geom_rbound[geom2]
 
@@ -656,7 +540,7 @@ def nxn_broadphase(m: Model, d: Data):
       dist = wp.dot(dif, wp.vec3(xmat1[0, 2], xmat1[1, 2], xmat1[2, 2]))
       bounds_filter = dist <= bound
     else:
-      # geom2 is a plane      
+      # geom2 is a plane
       xmat2 = d.geom_xmat[worldid, geom2]
       dist = wp.dot(-dif, wp.vec3(xmat2[0, 2], xmat2[1, 2], xmat2[2, 2]))
       bounds_filter = dist <= bound

--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -462,7 +462,6 @@ def make_data(
   d.broadphase_result_count = wp.zeros(nworld, dtype=wp.int32)
 
   # internal broadphase tmp arrays
-  #d.boxes_sorted = wp.zeros((nworld, mjm.ngeom, 2), dtype=wp.vec3)
   d.spheres_sorted = wp.zeros((nworld, mjm.ngeom), dtype=wp.vec4)
   d.box_projections_lower = wp.zeros((2 * nworld, mjm.ngeom), dtype=wp.float32)
   d.box_projections_upper = wp.zeros((nworld, mjm.ngeom), dtype=wp.float32)
@@ -693,7 +692,6 @@ def put_data(
   d.broadphase_result_count = wp.zeros(nworld, dtype=wp.int32)
 
   # internal broadphase tmp arrays
-  #d.boxes_sorted = wp.zeros((nworld, mjm.ngeom, 2), dtype=wp.vec3)
   d.spheres_sorted = wp.zeros((nworld, mjm.ngeom), dtype=wp.vec4)
   d.box_projections_lower = wp.zeros((2 * nworld, mjm.ngeom), dtype=wp.float32)
   d.box_projections_upper = wp.zeros((nworld, mjm.ngeom), dtype=wp.float32)
@@ -702,7 +700,6 @@ def put_data(
   d.cumulative_sum = wp.zeros(nworld * mjm.ngeom, dtype=wp.int32)
   segment_indices_list = [i * mjm.ngeom for i in range(nworld + 1)]
   d.segment_indices = wp.array(segment_indices_list, dtype=int)
-  #d.dyn_geom_aabb = wp.zeros((nworld, mjm.ngeom, 2), dtype=wp.vec3)
 
   # internal narrowphase tmp arrays
   ngroups = types.NUM_GEOM_TYPES * types.NUM_GEOM_TYPES

--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -462,7 +462,8 @@ def make_data(
   d.broadphase_result_count = wp.zeros(nworld, dtype=wp.int32)
 
   # internal broadphase tmp arrays
-  d.boxes_sorted = wp.zeros((nworld, mjm.ngeom, 2), dtype=wp.vec3)
+  #d.boxes_sorted = wp.zeros((nworld, mjm.ngeom, 2), dtype=wp.vec3)
+  d.spheres_sorted = wp.zeros((nworld, mjm.ngeom), dtype=wp.vec4)
   d.box_projections_lower = wp.zeros((2 * nworld, mjm.ngeom), dtype=wp.float32)
   d.box_projections_upper = wp.zeros((nworld, mjm.ngeom), dtype=wp.float32)
   d.box_sorting_indexer = wp.zeros((2 * nworld, mjm.ngeom), dtype=wp.int32)
@@ -692,7 +693,8 @@ def put_data(
   d.broadphase_result_count = wp.zeros(nworld, dtype=wp.int32)
 
   # internal broadphase tmp arrays
-  d.boxes_sorted = wp.zeros((nworld, mjm.ngeom, 2), dtype=wp.vec3)
+  #d.boxes_sorted = wp.zeros((nworld, mjm.ngeom, 2), dtype=wp.vec3)
+  d.spheres_sorted = wp.zeros((nworld, mjm.ngeom), dtype=wp.vec4)
   d.box_projections_lower = wp.zeros((2 * nworld, mjm.ngeom), dtype=wp.float32)
   d.box_projections_upper = wp.zeros((nworld, mjm.ngeom), dtype=wp.float32)
   d.box_sorting_indexer = wp.zeros((2 * nworld, mjm.ngeom), dtype=wp.int32)
@@ -700,7 +702,7 @@ def put_data(
   d.cumulative_sum = wp.zeros(nworld * mjm.ngeom, dtype=wp.int32)
   segment_indices_list = [i * mjm.ngeom for i in range(nworld + 1)]
   d.segment_indices = wp.array(segment_indices_list, dtype=int)
-  d.dyn_geom_aabb = wp.zeros((nworld, mjm.ngeom, 2), dtype=wp.vec3)
+  #d.dyn_geom_aabb = wp.zeros((nworld, mjm.ngeom, 2), dtype=wp.vec3)
 
   # internal narrowphase tmp arrays
   ngroups = types.NUM_GEOM_TYPES * types.NUM_GEOM_TYPES

--- a/mujoco_warp/_src/types.py
+++ b/mujoco_warp/_src/types.py
@@ -482,7 +482,6 @@ class Data:
   max_num_overlaps_per_world: int
   broadphase_pairs: wp.array(dtype=wp.vec2i, ndim=2)
   broadphase_result_count: wp.array(dtype=wp.int32, ndim=1)
-  #boxes_sorted: wp.array(dtype=wp.vec3, ndim=3)
   spheres_sorted: wp.array(dtype=wp.vec4, ndim=2)
   box_projections_lower: wp.array(dtype=wp.float32, ndim=2)
   box_projections_upper: wp.array(dtype=wp.float32, ndim=2)
@@ -490,7 +489,6 @@ class Data:
   ranges: wp.array(dtype=wp.int32, ndim=2)
   cumulative_sum: wp.array(dtype=wp.int32, ndim=1)
   segment_indices: wp.array(dtype=wp.int32, ndim=1)
-  #dyn_geom_aabb: wp.array(dtype=wp.vec3, ndim=3)
 
   # narrowphase temp arrays
   narrowphase_candidate_worldid: wp.array(dtype=wp.int32, ndim=2)

--- a/mujoco_warp/_src/types.py
+++ b/mujoco_warp/_src/types.py
@@ -482,14 +482,15 @@ class Data:
   max_num_overlaps_per_world: int
   broadphase_pairs: wp.array(dtype=wp.vec2i, ndim=2)
   broadphase_result_count: wp.array(dtype=wp.int32, ndim=1)
-  boxes_sorted: wp.array(dtype=wp.vec3, ndim=3)
+  #boxes_sorted: wp.array(dtype=wp.vec3, ndim=3)
+  spheres_sorted: wp.array(dtype=wp.vec4, ndim=2)
   box_projections_lower: wp.array(dtype=wp.float32, ndim=2)
   box_projections_upper: wp.array(dtype=wp.float32, ndim=2)
   box_sorting_indexer: wp.array(dtype=wp.int32, ndim=2)
   ranges: wp.array(dtype=wp.int32, ndim=2)
   cumulative_sum: wp.array(dtype=wp.int32, ndim=1)
   segment_indices: wp.array(dtype=wp.int32, ndim=1)
-  dyn_geom_aabb: wp.array(dtype=wp.vec3, ndim=3)
+  #dyn_geom_aabb: wp.array(dtype=wp.vec3, ndim=3)
 
   # narrowphase temp arrays
   narrowphase_candidate_worldid: wp.array(dtype=wp.int32, ndim=2)


### PR DESCRIPTION
Add proper plane support for the sweep and prune broad phase and switch to using bounding spheres similar as the n^2 broad phase does it. Going back to boxes is possible but spheres simplify the handling of plane interactions.
tile_sort support is in the MR too but deactivated since the feature is not yet in warp.