### PR TITLE
modify narrowphase

### DIFF
--- a/mujoco_warp/_src/collision_driver.py
+++ b/mujoco_warp/_src/collision_driver.py
@@ -294,9 +294,7 @@ def broadphase_sweep_and_prune_kernel(
         return
 
       pair = _geom_pair(m, idx1, idx2)
-      key = group_key(m.geom_type[idx1], m.geom_type[idx2])
       d.collision_pair[pairid] = pair
-      d.collision_type[pairid] = key
       d.collision_worldid[pairid] = worldId
 
     threadId += num_threads
@@ -506,9 +504,7 @@ def nxn_broadphase(m: Model, d: Data):
         return
 
       pair = _geom_pair(m, geom1, geom2)
-      key = group_key(type1, type2)
       d.collision_pair[pairid] = pair
-      d.collision_type[pairid] = key
       d.collision_worldid[pairid] = worldid
 
   wp.launch(

--- a/mujoco_warp/_src/collision_driver.py
+++ b/mujoco_warp/_src/collision_driver.py
@@ -15,7 +15,6 @@
 
 import warp as wp
 
-from .support import group_key
 from .support import where
 from .types import MJ_MINVAL
 from .types import Data

--- a/mujoco_warp/_src/collision_functions.py
+++ b/mujoco_warp/_src/collision_functions.py
@@ -30,11 +30,11 @@ class Geom:
   rot: wp.mat33
   normal: wp.vec3
   size: wp.vec3
+  # TODO(team): mesh fields: vertadr, vertnum
 
 
 @wp.func
 def _geom(
-  t: int,
   gid: int,
   m: Model,
   geom_xpos: wp.array(dtype=wp.vec3),
@@ -45,9 +45,7 @@ def _geom(
   rot = geom_xmat[gid]
   geom.rot = rot
   geom.size = m.geom_size[gid]
-
-  if t == int(GeomType.PLANE.value):
-    geom.normal = wp.vec3(rot[0, 2], rot[1, 2], rot[2, 2])
+  geom.normal = wp.vec3(rot[0, 2], rot[1, 2], rot[2, 2])  # plane
 
   return geom
 
@@ -253,8 +251,8 @@ def _narrowphase(
   type1 = m.geom_type[g1]
   type2 = m.geom_type[g2]
 
-  geom1 = _geom(type1, g1, m, d.geom_xpos[worldid], d.geom_xmat[worldid])
-  geom2 = _geom(type2, g2, m, d.geom_xpos[worldid], d.geom_xmat[worldid])
+  geom1 = _geom(g1, m, d.geom_xpos[worldid], d.geom_xmat[worldid])
+  geom2 = _geom(g2, m, d.geom_xpos[worldid], d.geom_xmat[worldid])
 
   margin = wp.max(m.geom_margin[g1], m.geom_margin[g2])
 

--- a/mujoco_warp/_src/collision_functions.py
+++ b/mujoco_warp/_src/collision_functions.py
@@ -18,7 +18,6 @@ import warp as wp
 from .math import closest_segment_to_segment_points
 from .math import make_frame
 from .math import normalize_with_norm
-from .support import group_key
 from .types import Data
 from .types import GeomType
 from .types import Model

--- a/mujoco_warp/_src/collision_functions.py
+++ b/mujoco_warp/_src/collision_functions.py
@@ -25,122 +25,31 @@ from .types import Model
 
 
 @wp.struct
-class GeomPlane:
+class Geom:
   pos: wp.vec3
   rot: wp.mat33
   normal: wp.vec3
-
-
-@wp.struct
-class GeomSphere:
-  pos: wp.vec3
-  rot: wp.mat33
-  radius: float
-
-
-@wp.struct
-class GeomCapsule:
-  pos: wp.vec3
-  rot: wp.mat33
-  radius: float
-  halfsize: float
-
-
-@wp.struct
-class GeomEllipsoid:
-  pos: wp.vec3
-  rot: wp.mat33
   size: wp.vec3
 
 
-@wp.struct
-class GeomCylinder:
-  pos: wp.vec3
-  rot: wp.mat33
-  radius: float
-  halfsize: float
+@wp.func
+def _geom(
+  t: int,
+  gid: int,
+  m: Model,
+  geom_xpos: wp.array(dtype=wp.vec3),
+  geom_xmat: wp.array(dtype=wp.mat33),
+) -> Geom:
+  geom = Geom()
+  geom.pos = geom_xpos[gid]
+  rot = geom_xmat[gid]
+  geom.rot = rot
+  geom.size = m.geom_size[gid]
 
+  if t == int(GeomType.PLANE.value):
+    geom.normal = wp.vec3(rot[0, 2], rot[1, 2], rot[2, 2])
 
-@wp.struct
-class GeomBox:
-  pos: wp.vec3
-  rot: wp.mat33
-  size: wp.vec3
-
-
-@wp.struct
-class GeomMesh:
-  pos: wp.vec3
-  rot: wp.mat33
-  vertadr: int
-  vertnum: int
-
-
-def get_info(t):
-  @wp.func
-  def _get_info(
-    gid: int,
-    m: Model,
-    geom_xpos: wp.array(dtype=wp.vec3),
-    geom_xmat: wp.array(dtype=wp.mat33),
-  ):
-    pos = geom_xpos[gid]
-    rot = geom_xmat[gid]
-    size = m.geom_size[gid]
-    if wp.static(t == GeomType.SPHERE.value):
-      sphere = GeomSphere()
-      sphere.pos = pos
-      sphere.rot = rot
-      sphere.radius = size[0]
-      return sphere
-    elif wp.static(t == GeomType.BOX.value):
-      box = GeomBox()
-      box.pos = pos
-      box.rot = rot
-      box.size = size
-      return box
-    elif wp.static(t == GeomType.PLANE.value):
-      plane = GeomPlane()
-      plane.pos = pos
-      plane.rot = rot
-      plane.normal = wp.vec3(rot[0, 2], rot[1, 2], rot[2, 2])
-      return plane
-    elif wp.static(t == GeomType.CAPSULE.value):
-      capsule = GeomCapsule()
-      capsule.pos = pos
-      capsule.rot = rot
-      capsule.radius = size[0]
-      capsule.halfsize = size[1]
-      return capsule
-    elif wp.static(t == GeomType.ELLIPSOID.value):
-      ellipsoid = GeomEllipsoid()
-      ellipsoid.pos = pos
-      ellipsoid.rot = rot
-      ellipsoid.size = size
-      return ellipsoid
-    elif wp.static(t == GeomType.CYLINDER.value):
-      cylinder = GeomCylinder()
-      cylinder.pos = pos
-      cylinder.rot = rot
-      cylinder.radius = size[0]
-      cylinder.halfsize = size[1]
-      return cylinder
-    elif wp.static(t == GeomType.MESH.value):
-      mesh = GeomMesh()
-      mesh.pos = pos
-      mesh.rot = rot
-      dataid = m.geom_dataid[gid]
-      if dataid >= 0:
-        mesh.vertadr = m.mesh_vertadr[dataid]
-        mesh.vertnum = m.mesh_vertnum[dataid]
-      else:
-        mesh.vertadr = 0
-        mesh.vertnum = 0
-      return mesh
-    else:
-      wp.static(RuntimeError("Unsupported type", t))
-
-  return _get_info
+  return geom
 
 
 @wp.func
@@ -175,14 +84,14 @@ def _plane_sphere(
 
 @wp.func
 def plane_sphere(
-  plane: GeomPlane,
-  sphere: GeomSphere,
+  plane: Geom,
+  sphere: Geom,
   worldid: int,
   d: Data,
   margin: float,
   geom_indices: wp.vec2i,
 ):
-  dist, pos = _plane_sphere(plane.normal, plane.pos, sphere.pos, sphere.radius)
+  dist, pos = _plane_sphere(plane.normal, plane.pos, sphere.pos, sphere.size[0])
 
   write_contact(d, dist, pos, make_frame(plane.normal), margin, geom_indices, worldid)
 
@@ -212,8 +121,8 @@ def _sphere_sphere(
 
 @wp.func
 def sphere_sphere(
-  sphere1: GeomSphere,
-  sphere2: GeomSphere,
+  sphere1: Geom,
+  sphere2: Geom,
   worldid: int,
   d: Data,
   margin: float,
@@ -221,9 +130,9 @@ def sphere_sphere(
 ):
   _sphere_sphere(
     sphere1.pos,
-    sphere1.radius,
+    sphere1.size[0],
     sphere2.pos,
-    sphere2.radius,
+    sphere2.size[0],
     worldid,
     d,
     margin,
@@ -233,8 +142,8 @@ def sphere_sphere(
 
 @wp.func
 def capsule_capsule(
-  cap1: GeomCapsule,
-  cap2: GeomCapsule,
+  cap1: Geom,
+  cap2: Geom,
   worldid: int,
   d: Data,
   margin: float,
@@ -242,8 +151,8 @@ def capsule_capsule(
 ):
   axis1 = wp.vec3(cap1.rot[0, 2], cap1.rot[1, 2], cap1.rot[2, 2])
   axis2 = wp.vec3(cap2.rot[0, 2], cap2.rot[1, 2], cap2.rot[2, 2])
-  length1 = cap1.halfsize
-  length2 = cap2.halfsize
+  length1 = cap1.size[1]
+  length2 = cap2.size[1]
   seg1 = axis1 * length1
   seg2 = axis2 * length2
 
@@ -254,13 +163,13 @@ def capsule_capsule(
     cap2.pos + seg2,
   )
 
-  _sphere_sphere(pt1, cap1.radius, pt2, cap2.radius, worldid, d, margin, geom_indices)
+  _sphere_sphere(pt1, cap1.size[0], pt2, cap2.size[0], worldid, d, margin, geom_indices)
 
 
 @wp.func
 def plane_capsule(
-  plane: GeomPlane,
-  cap: GeomCapsule,
+  plane: Geom,
+  cap: Geom,
   worldid: int,
   d: Data,
   margin: float,
@@ -280,19 +189,19 @@ def plane_capsule(
 
   c = wp.cross(n, b)
   frame = wp.mat33(n[0], n[1], n[2], b[0], b[1], b[2], c[0], c[1], c[2])
-  segment = axis * cap.halfsize
+  segment = axis * cap.size[1]
 
-  dist1, pos1 = _plane_sphere(n, plane.pos, cap.pos + segment, cap.radius)
+  dist1, pos1 = _plane_sphere(n, plane.pos, cap.pos + segment, cap.size[0])
   write_contact(d, dist1, pos1, frame, margin, geom_indices, worldid)
 
-  dist2, pos2 = _plane_sphere(n, plane.pos, cap.pos - segment, cap.radius)
+  dist2, pos2 = _plane_sphere(n, plane.pos, cap.pos - segment, cap.size[0])
   write_contact(d, dist2, pos2, frame, margin, geom_indices, worldid)
 
 
 @wp.func
 def plane_box(
-  plane: GeomPlane,
-  box: GeomBox,
+  plane: Geom,
+  box: Geom,
   worldid: int,
   d: Data,
   margin: float,
@@ -326,72 +235,43 @@ def plane_box(
       break
 
 
-_collision_functions = {
-  (GeomType.PLANE.value, GeomType.SPHERE.value): plane_sphere,
-  (GeomType.SPHERE.value, GeomType.SPHERE.value): sphere_sphere,
-  (GeomType.PLANE.value, GeomType.CAPSULE.value): plane_capsule,
-  (GeomType.PLANE.value, GeomType.BOX.value): plane_box,
-  (GeomType.CAPSULE.value, GeomType.CAPSULE.value): capsule_capsule,
-}
+@wp.kernel
+def _narrowphase(
+  m: Model,
+  d: Data,
+):
+  tid = wp.tid()
 
+  if tid >= d.ncollision[0]:
+    return
 
-def create_collision_function_kernel(type1, type2):
-  key = group_key(type1, type2)
+  geoms = d.collision_pair[tid]
+  worldid = d.collision_worldid[tid]
 
-  @wp.kernel
-  def _collision_function_kernel(
-    m: Model,
-    d: Data,
-  ):
-    tid = wp.tid()
+  g1 = geoms[0]
+  g2 = geoms[1]
+  type1 = m.geom_type[g1]
+  type2 = m.geom_type[g2]
 
-    if tid >= d.ncollision[0] or d.collision_type[tid] != key:
-      return
+  geom1 = _geom(type1, g1, m, d.geom_xpos[worldid], d.geom_xmat[worldid])
+  geom2 = _geom(type2, g2, m, d.geom_xpos[worldid], d.geom_xmat[worldid])
 
-    geoms = d.collision_pair[tid]
-    worldid = d.collision_worldid[tid]
+  margin = wp.max(m.geom_margin[g1], m.geom_margin[g2])
 
-    # TODO(team): per-world maximum number of collisions?
-
-    g1 = geoms[0]
-    g2 = geoms[1]
-
-    geom1 = wp.static(get_info(type1))(
-      g1,
-      m,
-      d.geom_xpos[worldid],
-      d.geom_xmat[worldid],
-    )
-    geom2 = wp.static(get_info(type2))(
-      g2,
-      m,
-      d.geom_xpos[worldid],
-      d.geom_xmat[worldid],
-    )
-
-    margin = wp.max(m.geom_margin[g1], m.geom_margin[g2])
-
-    wp.static(_collision_functions[(type1, type2)])(
-      geom1, geom2, worldid, d, margin, geoms
-    )
-
-  return _collision_function_kernel
-
-
-_collision_kernels = {}
+  # TODO(team): static loop unrolling to remove unnecessary branching
+  if type1 == int(GeomType.PLANE.value) and type2 == int(GeomType.SPHERE.value):
+    plane_sphere(geom1, geom2, worldid, d, margin, geoms)
+  elif type1 == int(GeomType.SPHERE.value) and type2 == int(GeomType.SPHERE.value):
+    sphere_sphere(geom1, geom2, worldid, d, margin, geoms)
+  elif type1 == int(GeomType.PLANE.value) and type2 == int(GeomType.CAPSULE.value):
+    plane_capsule(geom1, geom2, worldid, d, margin, geoms)
+  elif type1 == int(GeomType.PLANE.value) and type2 == int(GeomType.BOX.value):
+    plane_box(geom1, geom2, worldid, d, margin, geoms)
+  elif type1 == int(GeomType.CAPSULE.value) and type2 == int(GeomType.CAPSULE.value):
+    capsule_capsule(geom1, geom2, worldid, d, margin, geoms)
 
 
 def narrowphase(m: Model, d: Data):
   # we need to figure out how to keep the overhead of this small - not launching anything
   # for pair types without collisions, as well as updating the launch dimensions.
-
-  # TODO(team): investigate a single kernel launch for all collision functions
-  # TODO only generate collision kernels we actually need
-  if len(_collision_kernels) == 0:
-    for type1, type2 in _collision_functions.keys():
-      _collision_kernels[(type1, type2)] = create_collision_function_kernel(
-        type1, type2
-      )
-
-  for collision_kernel in _collision_kernels.values():
-    wp.launch(collision_kernel, dim=d.nconmax, inputs=[m, d])
+  wp.launch(_narrowphase, dim=d.nconmax, inputs=[m, d])

--- a/mujoco_warp/_src/io.py
+++ b/mujoco_warp/_src/io.py
@@ -475,7 +475,6 @@ def make_data(
 
   # collision driver
   d.collision_pair = wp.empty(nconmax, dtype=wp.vec2i, ndim=1)
-  d.collision_type = wp.empty(nconmax, dtype=wp.int32, ndim=1)
   d.collision_worldid = wp.empty(nconmax, dtype=wp.int32, ndim=1)
   d.ncollision = wp.zeros(1, dtype=wp.int32, ndim=1)
 
@@ -699,7 +698,6 @@ def put_data(
 
   # collision driver
   d.collision_pair = wp.empty(nconmax, dtype=wp.vec2i, ndim=1)
-  d.collision_type = wp.empty(nconmax, dtype=wp.int32, ndim=1)
   d.collision_worldid = wp.empty(nconmax, dtype=wp.int32, ndim=1)
   d.ncollision = wp.zeros(1, dtype=wp.int32, ndim=1)
 

--- a/mujoco_warp/_src/support.py
+++ b/mujoco_warp/_src/support.py
@@ -178,14 +178,6 @@ def bisection(x: wp.array(dtype=int), v: int, a_: int, b_: int) -> int:
 
 
 @wp.func
-def group_key(type1: wp.int32, type2: wp.int32) -> wp.int32:
-  if type1 > type2:
-    return type2 + type1 * NUM_GEOM_TYPES
-  else:
-    return type1 + type2 * NUM_GEOM_TYPES
-
-
-@wp.func
 def mat33_from_rows(a: wp.vec3, b: wp.vec3, c: wp.vec3):
   return wp.mat33(a, b, c)
 

--- a/mujoco_warp/_src/types.py
+++ b/mujoco_warp/_src/types.py
@@ -491,6 +491,5 @@ class Data:
 
   # collision driver
   collision_pair: wp.array(dtype=wp.vec2i, ndim=1)
-  collision_type: wp.array(dtype=wp.int32, ndim=1)
   collision_worldid: wp.array(dtype=wp.int32, ndim=1)
   ncollision: wp.array(dtype=wp.int32, ndim=1)


### PR DESCRIPTION
modifications to narrowphase to launch one kernel for all collision functions instead of launching one kernel per collision function.

humanoid
```
mjwarp-testspeed --function=collision --mjcf=humanoid/humanoid.xml --batch_size=8192
```

this pr:
```
Summary for 8192 parallel rollouts

 Total JIT time: 0.02 s
 Total simulation time: 0.10 s
 Total steps per second: 84,543,850
 Total realtime factor: 422,719.25 x
 Total time per step: 11.83 ns
```

main:
```
Summary for 8192 parallel rollouts

 Total JIT time: 0.05 s
 Total simulation time: 0.11 s
 Total steps per second: 73,888,460
 Total realtime factor: 369,442.30 x
 Total time per step: 13.53 ns
```

collision.xml
```
mjwarp-testspeed --function=collision --mjcf=collision.xml --batch_size=8192
```

this pr:
```
Summary for 8192 parallel rollouts

 Total JIT time: 0.02 s
 Total simulation time: 0.12 s
 Total steps per second: 66,502,785
 Total realtime factor: 133,005.57 x
 Total time per step: 15.04 ns
```

main:
```
Summary for 8192 parallel rollouts

 Total JIT time: 0.05 s
 Total simulation time: 0.16 s
 Total steps per second: 52,536,337
 Total realtime factor: 105,072.67 x
 Total time per step: 19.03 ns
```