### PR TITLE
Remove event_scope from _linesearch.

### DIFF
--- a/mujoco_warp/_src/solver.py
+++ b/mujoco_warp/_src/solver.py
@@ -283,7 +283,6 @@ def _safe_div(x: wp.float32, y: wp.float32) -> wp.float32:
   return x / wp.where(y != 0.0, y, types.MJ_MINVAL)
 
 
-@event_scope
 def _linesearch_iterative(m: types.Model, d: types.Data):
   @kernel
   def _gtol(m: types.Model, d: types.Data):


### PR DESCRIPTION
Prevents crashing when running mjwarp-testspeed with --event_trace=True.

I think this is because of nested traces from solve -> linesarch -> mul_m which the tracer does not handle correctly.