### PR TITLE
Add support to testspeed to measure ncon, nefc during unroll.

### DIFF
--- a/mujoco_warp/testspeed.py
+++ b/mujoco_warp/testspeed.py
@@ -19,6 +19,7 @@ import inspect
 from typing import Sequence
 
 import mujoco
+import numpy as np
 import warp as wp
 from absl import app
 from absl import flags
@@ -62,6 +63,7 @@ _CLEAR_KERNEL_CACHE = flags.DEFINE_bool(
   "clear_kernel_cache", False, "Clear kernel cache (to calculate full JIT time)"
 )
 _EVENT_TRACE = flags.DEFINE_bool("event_trace", False, "Provide a full event trace")
+_MEASURE_ALLOC = flags.DEFINE_bool("measure_alloc", False, "Measure how much of nconmax, njmax is used.")
 
 
 def _main(argv: Sequence[str]):
@@ -95,7 +97,7 @@ def _main(argv: Sequence[str]):
   )
   print(f"Data ncon: {d.ncon} nefc: {d.nefc} keyframe: {_KEYFRAME.value}")
   print(f"Rolling out {_NSTEP.value} steps at dt = {m.opt.timestep:.3f}...")
-  jit_time, run_time, trace, steps = mjwarp.benchmark(
+  jit_time, run_time, trace, steps, ncon, nefc = mjwarp.benchmark(
     mjwarp.__dict__[_FUNCTION.value],
     m,
     d,
@@ -107,6 +109,7 @@ def _main(argv: Sequence[str]):
     _NCONMAX.value,
     _NJMAX.value,
     _EVENT_TRACE.value,
+    _MEASURE_ALLOC.value,
   )
 
   name = argv[0]
@@ -136,6 +139,33 @@ Summary for {_BATCH_SIZE.value} parallel rollouts
           _print_trace(sub_trace, indent + 1)
 
       _print_trace(trace, 0)
+    if ncon and nefc:
+      num_buckets = 10
+      idx = 0
+      ncon_matrix, nefc_matrix = [], []
+      for i in range(num_buckets):
+        size = _NSTEP.value // num_buckets + (i < (_NSTEP.value % num_buckets))
+        ncon_arr = np.array(ncon[idx:idx+size])
+        nefc_arr = np.array(nefc[idx:idx+size])
+        ncon_matrix.append([np.mean(ncon_arr), np.std(ncon_arr), np.min(ncon_arr), np.max(ncon_arr)])
+        nefc_matrix.append([np.mean(nefc_arr), np.std(nefc_arr), np.min(nefc_arr), np.max(nefc_arr)])
+        idx += size
+
+      def _print_table(matrix, headers):
+        num_cols = len(headers)
+        col_widths = [max(len(f"{row[i]:g}") for row in matrix) for i in range(num_cols)]
+        col_widths = [max(col_widths[i], len(headers[i])) for i in range(num_cols)]
+        
+        print("  ".join(f"{headers[i]:<{col_widths[i]}}" for i in range(num_cols)))
+        print("-" * sum(col_widths) + "--" * 3)  # Separator line
+        for row in matrix:
+          print("  ".join(f"{row[i]:{col_widths[i]}g}" for i in range(num_cols)))
+      
+      print("\nncon alloc:\n")
+      _print_table(ncon_matrix, ("mean", "std", "min", "max"))
+      print("\nnefc alloc:\n")
+      _print_table(nefc_matrix, ("mean", "std", "min", "max"))
+
 
   elif _OUTPUT.value == "tsv":
     name = name.split("/")[-1].replace("testspeed_", "")

--- a/mujoco_warp/testspeed.py
+++ b/mujoco_warp/testspeed.py
@@ -97,6 +97,7 @@ def _main(argv: Sequence[str]):
   print(
     f"Model nbody: {m.nbody} nv: {m.nv} ngeom: {m.ngeom} is_sparse: {_IS_SPARSE.value} solver: {_SOLVER.value}"
   )
+  print(f"Params nconmax: {_NCONMAX.value} njmax: {_NJMAX.value}")
   print(f"Data ncon: {d.ncon} nefc: {d.nefc} keyframe: {_KEYFRAME.value}")
   print(f"Rolling out {_NSTEP.value} steps at dt = {m.opt.timestep:.3f}...")
   jit_time, run_time, trace, steps, ncon, nefc = mjwarp.benchmark(

--- a/mujoco_warp/testspeed.py
+++ b/mujoco_warp/testspeed.py
@@ -63,7 +63,9 @@ _CLEAR_KERNEL_CACHE = flags.DEFINE_bool(
   "clear_kernel_cache", False, "Clear kernel cache (to calculate full JIT time)"
 )
 _EVENT_TRACE = flags.DEFINE_bool("event_trace", False, "Provide a full event trace")
-_MEASURE_ALLOC = flags.DEFINE_bool("measure_alloc", False, "Measure how much of nconmax, njmax is used.")
+_MEASURE_ALLOC = flags.DEFINE_bool(
+  "measure_alloc", False, "Measure how much of nconmax, njmax is used."
+)
 
 
 def _main(argv: Sequence[str]):
@@ -145,27 +147,32 @@ Summary for {_BATCH_SIZE.value} parallel rollouts
       ncon_matrix, nefc_matrix = [], []
       for i in range(num_buckets):
         size = _NSTEP.value // num_buckets + (i < (_NSTEP.value % num_buckets))
-        ncon_arr = np.array(ncon[idx:idx+size])
-        nefc_arr = np.array(nefc[idx:idx+size])
-        ncon_matrix.append([np.mean(ncon_arr), np.std(ncon_arr), np.min(ncon_arr), np.max(ncon_arr)])
-        nefc_matrix.append([np.mean(nefc_arr), np.std(nefc_arr), np.min(nefc_arr), np.max(nefc_arr)])
+        ncon_arr = np.array(ncon[idx : idx + size])
+        nefc_arr = np.array(nefc[idx : idx + size])
+        ncon_matrix.append(
+          [np.mean(ncon_arr), np.std(ncon_arr), np.min(ncon_arr), np.max(ncon_arr)]
+        )
+        nefc_matrix.append(
+          [np.mean(nefc_arr), np.std(nefc_arr), np.min(nefc_arr), np.max(nefc_arr)]
+        )
         idx += size
 
       def _print_table(matrix, headers):
         num_cols = len(headers)
-        col_widths = [max(len(f"{row[i]:g}") for row in matrix) for i in range(num_cols)]
+        col_widths = [
+          max(len(f"{row[i]:g}") for row in matrix) for i in range(num_cols)
+        ]
         col_widths = [max(col_widths[i], len(headers[i])) for i in range(num_cols)]
-        
+
         print("  ".join(f"{headers[i]:<{col_widths[i]}}" for i in range(num_cols)))
         print("-" * sum(col_widths) + "--" * 3)  # Separator line
         for row in matrix:
           print("  ".join(f"{row[i]:{col_widths[i]}g}" for i in range(num_cols)))
-      
+
       print("\nncon alloc:\n")
       _print_table(ncon_matrix, ("mean", "std", "min", "max"))
       print("\nnefc alloc:\n")
       _print_table(nefc_matrix, ("mean", "std", "min", "max"))
-
 
   elif _OUTPUT.value == "tsv":
     name = name.split("/")[-1].replace("testspeed_", "")


### PR DESCRIPTION
Example output with `--measure_alloc=True`:

```

Summary for 8192 parallel rollouts

 Total JIT time: 0.70 s
 Total simulation time: 2.34 s
 Total steps per second: 3,499,428
 Total realtime factor: 17,497.14 x
 Total time per step: 285.76 ns

ncon alloc:

mean     std      min    max  
------------------------------
9469.66  3533.48   3370  19076
11517.8   1136.6   9254  13604
14650.3  1296.75  13021  16324
16305.6  73.2343  16123  16481
16647.1  200.947  16223  17020
16620.7  164.378  16278  17010
16082.2  239.614  15568  16508
15480.4  113.169  15225  15851
15450.9  67.1437  15285  15585
15507.4  76.9735  15365  15780

nefc alloc:

mean     std      min    max  
------------------------------
45211.6  13792.1  17659  78061
61505.3  6728.46  53218  77000
70598.8   4682.4  64598  76554
  76262  338.235  75381  76989
77178.2  720.694  75658  78568
  77533  2683.08  75634  87431
82172.5  5787.12  72980  87288
72624.6  561.747  71611  74197
71776.6    252.1  70978  72420
71864.8  310.849  71263  72954
```