### PR TITLE
Optimizing kernel _JTDAJ

### DIFF
--- a/mujoco_warp/_src/solver.py
+++ b/mujoco_warp/_src/solver.py
@@ -247,33 +247,37 @@ def _update_gradient(m: types.Model, d: types.Data):
       d.efc.h[worldid, rowid, colid] = d.qM[worldid, rowid, colid]
 
   @kernel
-  def _JTDAJ(m: types.Model, d: types.Data):
+  def _JTDAJ(m: types.Model, d: types.Data,
+             nblocks_perblock: int, dim_x: int):
     # TODO(team): static m?
-    efcid, elementid = wp.tid()
+    efcid_temp, elementid = wp.tid()
 
-    if efcid >= d.nefc[0]:
-      return
-
-    worldid = d.efc.worldid[efcid]
-
-    if ITERATIONS > 1:
-      if d.efc.done[worldid]:
+    for i in range(nblocks_perblock):
+      efcid = efcid_temp + i*dim_x
+    
+      if efcid >= d.nefc[0]:
         return
 
-    dofi = m.dof_tri_row[elementid]
-    dofj = m.dof_tri_col[elementid]
+      worldid = d.efc.worldid[efcid]
 
-    efc_D = d.efc.D[efcid]
-    active = d.efc.active[efcid]
-    if efc_D == 0.0 or active == 0:
-      return
+      if ITERATIONS > 1:
+        if d.efc.done[worldid]:
+          return
 
-    # TODO(team): sparse efc_J
-    wp.atomic_add(
-      d.efc.h[worldid, dofi],
-      dofj,
-      d.efc.J[efcid, dofi] * d.efc.J[efcid, dofj] * efc_D,
-    )
+      dofi = m.dof_tri_row[elementid]
+      dofj = m.dof_tri_col[elementid]
+
+      efc_D = d.efc.D[efcid]
+      active = d.efc.active[efcid]
+      if efc_D == 0.0 or active == 0:
+        return
+
+      # TODO(team): sparse efc_J
+      wp.atomic_add(
+        d.efc.h[worldid, dofi],
+        dofj,
+        d.efc.J[efcid, dofi] * d.efc.J[efcid, dofj] * efc_D,
+      )
 
   @kernel
   def _cholesky(d: types.Data):
@@ -307,7 +311,19 @@ def _update_gradient(m: types.Model, d: types.Data):
     else:
       wp.launch(_copy_lower_triangle, dim=(d.nworld, m.dof_tri_row.size), inputs=[m, d])
 
-    wp.launch(_JTDAJ, dim=(d.njmax, m.dof_tri_row.size), inputs=[m, d])
+    # Optimization: launching _JTDAJ with limited number of blocks. 
+    # Profiling suggests that only a fraction of blocks out of the original d.njmax blocks 
+    # do the actual work. It aims to minimize #CTAs with no effective work.
+    # It launch with #blocks that's proportional to the number of SMs on the GPU.
+    # We can now query the SM count: https://github.com/NVIDIA/warp/commit/f3814e7e5459e5fd13032cf0fddb3daddd510f30
+    sm_count = wp.get_device().sm_count 
+    dim_x = int((sm_count*6*256)/m.dof_tri_row.size)
+    
+    wp.launch(_JTDAJ, 
+              dim=(dim_x, m.dof_tri_row.size), 
+              inputs=[m, d, 
+                      int((d.njmax+dim_x-1)/dim_x),
+                      dim_x])
 
     wp.launch_tiled(_cholesky, dim=(d.nworld,), inputs=[d], block_dim=32)
 


### PR DESCRIPTION
To improve the efficiency of the `_JTDAJ` kernel, we have reduced the number of launched CTAs. Profiling indicated that the original kernel, launched with `dim_x = d.njmax` blocks, resulted in the execution of many blocks with no effective work. The optimized kernel now launches a number of blocks proportional to the GPU's SM count.

While running `mjwarp-testspeed --function=step --mjcf=humanoid/humanoid.xml --batch_size=8192` on an RTX A5000 at 1695MHz, the optimization reduced the kernel time spent on this kernel from 33.6% to 1.4%. These numbers are obtained from the CUDA GPU kernel summary page from the `nsys` reports.
